### PR TITLE
API-03: Jobs CRUD + BullMQ integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,3 +312,15 @@ pnpm -w install
 - Giorno 5: integrazione Leonardo + Asset manager.  
 - Giorno 6: worker video locale con ComfyUI.  
 - Giorno 7: workflow n8n end-to-end.
+
+## API Endpoints (summary)
+
+- POST /jobs
+  - Body: { "type": "content-generation|lora-training|video-generation", "payload": { ... }, "priority": 1 }
+  - Returns created Job (status pending) and enqueues on BullMQ
+- GET /jobs?status=&type=&take=&skip=
+  - Lists recent jobs
+- GET /jobs/:id
+  - Fetches a job by id
+
+Swagger: http://localhost:3001/api

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,15 +1,31 @@
-import { Module } from '@nestjs/common';
+﻿import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PrismaModule } from './prisma/prisma.module';
+import { BullModule } from '@nestjs/bullmq';
+import { JobsModule } from './jobs/jobs.module';
+
+function parseRedisUrl(url?: string) {
+  try {
+    const u = new URL(url || 'redis://localhost:6379');
+    return {
+      host: u.hostname,
+      port: Number(u.port || 6379),
+      username: u.username || undefined,
+      password: u.password || undefined,
+    } as any;
+  } catch {
+    return { host: 'localhost', port: 6379 } as any;
+  }
+}
 
 @Module({
   imports: [
-    ConfigModule.forRoot({
-      isGlobal: true,
-    }),
+    ConfigModule.forRoot({ isGlobal: true }),
     PrismaModule,
+    BullModule.forRoot({ connection: parseRedisUrl(process.env.REDIS_URL) }),
+    JobsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -20,11 +20,15 @@ function parseRedisUrl(url?: string) {
   }
 }
 
+const extraImports = process.env.NODE_ENV === 'test' ? [] : [
+  BullModule.forRoot({ connection: parseRedisUrl(process.env.REDIS_URL) }),
+];
+
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
     PrismaModule,
-    BullModule.forRoot({ connection: parseRedisUrl(process.env.REDIS_URL) }),
+    ...extraImports,
     JobsModule,
   ],
   controllers: [AppController],

--- a/apps/api/src/jobs/jobs.controller.ts
+++ b/apps/api/src/jobs/jobs.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Param, Post, Body, Query } from '@nestjs/common';
+import { JobsService } from './jobs.service';
+
+@Controller('jobs')
+export class JobsController {
+  constructor(private readonly jobsService: JobsService) {}
+
+  @Post()
+  create(@Body() body: { type: 'content-generation' | 'lora-training' | 'video-generation'; payload: Record<string, any>; priority?: number }) {
+    return this.jobsService.createJob(body);
+  }
+
+  @Get()
+  list(
+    @Query('status') status?: string,
+    @Query('type') type?: string,
+    @Query('take') take?: string,
+    @Query('skip') skip?: string,
+  ) {
+    return this.jobsService.listJobs({ status, type, take: take ? parseInt(take) : undefined, skip: skip ? parseInt(skip) : undefined });
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return this.jobsService.getJob(id);
+  }
+}
+

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bullmq';
+import { JobsService } from './jobs.service';
+import { JobsController } from './jobs.controller';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Module({
+  imports: [
+    BullModule.registerQueue(
+      { name: 'content-generation' },
+      { name: 'lora-training' },
+      { name: 'video-generation' },
+    ),
+  ],
+  controllers: [JobsController],
+  providers: [PrismaService, JobsService],
+})
+export class JobsModule {}
+

--- a/apps/api/src/jobs/jobs.service.spec.ts
+++ b/apps/api/src/jobs/jobs.service.spec.ts
@@ -1,0 +1,25 @@
+﻿import { Test } from '@nestjs/testing';
+import { JobsService } from './jobs.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+const queueMock = { add: jest.fn().mockResolvedValue(null) } as any;
+
+describe('JobsService', () => {
+  it('creates job and enqueues', async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        JobsService,
+        { provide: PrismaService, useValue: { job: { create: jest.fn().mockResolvedValue({ id: 'j1', type: 'content-generation' }) } } },
+        { provide: 'BullQueue_content-generation', useValue: queueMock },
+        { provide: 'BullQueue_lora-training', useValue: queueMock },
+        { provide: 'BullQueue_video-generation', useValue: queueMock },
+      ],
+    }).compile();
+
+    const svc = moduleRef.get(JobsService);
+    const job = await svc.createJob({ type: 'content-generation', payload: { foo: 'bar' } });
+
+    expect(job.id).toBe('j1');
+    expect(queueMock.add).toHaveBeenCalledWith('content-generation', expect.objectContaining({ jobId: 'j1', foo: 'bar' }), expect.any(Object));
+  });
+});

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { PrismaService } from '../prisma/prisma.service';
+
+type JobType = 'content-generation' | 'lora-training' | 'video-generation';
+
+@Injectable()
+export class JobsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    @InjectQueue('content-generation') private readonly contentQueue: Queue,
+    @InjectQueue('lora-training') private readonly loraQueue: Queue,
+    @InjectQueue('video-generation') private readonly videoQueue: Queue,
+  ) {}
+
+  async createJob(input: { type: JobType; payload: Record<string, any>; priority?: number }) {
+    const job = await this.prisma.job.create({
+      data: {
+        type: input.type,
+        status: 'pending',
+        payload: input.payload as any,
+      },
+    });
+
+    const queue = this.getQueue(input.type);
+    await queue.add(input.type, { jobId: job.id, ...input.payload }, {
+      priority: input.priority ?? 1,
+      removeOnComplete: true,
+      removeOnFail: false,
+    });
+
+    return job;
+  }
+
+  async listJobs(params: { status?: string; type?: string; take?: number; skip?: number }) {
+    const take = params.take ?? 20;
+    const skip = params.skip ?? 0;
+    return this.prisma.job.findMany({
+      where: {
+        status: params.status,
+        type: params.type,
+      },
+      orderBy: { createdAt: 'desc' },
+      take,
+      skip,
+    });
+  }
+
+  async getJob(id: string) {
+    return this.prisma.job.findUnique({ where: { id } });
+  }
+
+  private getQueue(type: JobType): Queue {
+    switch (type) {
+      case 'content-generation':
+        return this.contentQueue;
+      case 'lora-training':
+        return this.loraQueue;
+      case 'video-generation':
+        return this.videoQueue;
+      default:
+        return this.contentQueue;
+    }
+  }
+}
+

--- a/apps/api/test/jobs.e2e-spec.ts
+++ b/apps/api/test/jobs.e2e-spec.ts
@@ -1,0 +1,62 @@
+﻿import { Test, TestingModule } from '@nestjs/testing';
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { JobsService } from '../src/jobs/jobs.service';
+import { PrismaService } from '../src/prisma/prisma.service';
+
+describe('Jobs (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/db?schema=public';
+
+    const jobsServiceMock: Partial<JobsService> = {
+      createJob: jest.fn(async ({ type, payload }) => ({ id: 'job_2', type, status: 'pending', payload } as any)),
+      listJobs: jest.fn(async () => [{ id: 'job_1', type: 'content-generation', status: 'pending', payload: { foo: 'bar' } } as any]),
+      getJob: jest.fn(async (id: string) => ({ id, type: 'content-generation', status: 'pending', payload: {} } as any)),
+    };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(JobsService)
+      .useValue(jobsServiceMock)
+      .overrideProvider(PrismaService)
+      .useValue({ onModuleInit: jest.fn(), onModuleDestroy: jest.fn(), enableShutdownHooks: jest.fn() })
+      .compile();
+
+    app = moduleFixture.createNestApplication(new FastifyAdapter());
+    await app.init();
+    await app.getHttpAdapter().getInstance().ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('POST /jobs creates a job and enqueues', async () => {
+    const res = await (request as any)(app.getHttpServer())
+      .post('/jobs')
+      .send({ type: 'content-generation', payload: { foo: 'bar' } })
+      .expect(201);
+    expect(res.body).toMatchObject({ id: 'job_2', type: 'content-generation', status: 'pending' });
+  });
+
+  it('GET /jobs lists jobs', async () => {
+    const res = await (request as any)(app.getHttpServer())
+      .get('/jobs')
+      .expect(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toMatchObject({ id: 'job_1' });
+  });
+
+  it('GET /jobs/:id returns job', async () => {
+    const res = await (request as any)(app.getHttpServer())
+      .get('/jobs/job_42')
+      .expect(200);
+    expect(res.body).toMatchObject({ id: 'job_42' });
+  });
+});


### PR DESCRIPTION
Implements API-03 (Expose CRUD jobs and integrate BullMQ).\n\n- Adds JobsModule with POST /jobs, GET /jobs, GET /jobs/:id\n- Persists jobs via Prisma (status=pending) and enqueues to the appropriate BullMQ queue\n- Unit tests (JobsService) + existing PrismaService tests remain green\n- E2E scaffold present for health; further e2e for jobs can follow\n\nCloses #5