### PR TITLE
Feat/infra 01 initial prisma migration

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,9 @@
       "Bash(gh issue list:*)",
       "Bash(test:*)",
       "Bash(docker compose:*)",
-      "Bash(gh issue create:*)"
+      "Bash(gh issue create:*)",
+      "Bash(gh issue edit 4 --body \"$(cat <<''EOF''\n### Contesto\nLo schema Prisma con modelli Tenant, Influencer, Dataset, Job e Asset è già definito in `apps/api/prisma/schema.prisma`. Le migrazioni Prisma devono essere generate e applicate per creare effettivamente le tabelle nel database PostgreSQL. Gli script di generazione del client devono essere integrati nel workflow di sviluppo.\n\n### Stato Attuale\n- ✅ schema.prisma implementato con tutti i modelli richiesti\n- ❌ Nessuna migrazione generata in `apps/api/prisma/migrations/`\n- ❌ Database non inizializzato\n- ❌ Procedura di migrazione non documentata nella README API\n\n### DoD\n- [ ] Migrazione iniziale generata con `cd apps/api && pnpm dlx prisma migrate dev --name init`\n- [ ] Tabelle create e verificate nel database Postgres locale\n- [ ] Script `prisma:generate` verificato in `apps/api/package.json`\n- [ ] Documentata nella README API la procedura per applicare le migrazioni\n- [ ] Verificato che `docker compose up api` completa con successo dopo migrate\n\n### Dipendenze\n- [INFRA-01] Inizializzare database con Prisma migrations\n\n### Note Tecniche\nLo schema include:\n- Multi-tenancy via `Tenant` con cascade delete\n- `Influencer` con `persona` JSON e link opzionale a dataset\n- `Dataset` con `meta` JSON per training LoRA\n- `Job` con tracking costi token OpenRouter (`costTok`)\n- `Asset` per storage output generati (immagini/video)\n- Indici su relazioni e query frequenti (status, type, tenantId)\nEOF\n)\")",
+      "Bash(gh issue view:*)"
     ],
     "deny": [],
     "ask": []

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,8 @@ yarn-error.log*
 .turbo
 
 # Prisma
-apps/api/prisma/migrations/*
+# Keep migrations committed for reproducible schema
+# (Prisma client is generated in node_modules, not here)
 
 # Data directories
 data/datasets/*

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Unico costo previsto: **API OpenRouter** per generazione testi.
 
 ---
 
+## Documentazione
+
+- Setup ambiente: `docs/SETUP.md`
+- Testing: `docs/TESTING.md`
+
+---
+
 ## Executive Summary
 
 - Monorepo TS (Next.js dashboard, NestJS API, worker BullMQ) + n8n locale.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Unico costo previsto: **API OpenRouter** per generazione testi.
 
 ## Documentazione
 
-- Setup ambiente: `docs/SETUP.md`
-- Testing: `docs/TESTING.md`
+- Setup ambiente: [docs/SETUP.md](docs/SETUP.md)
+- Testing: [docs/TESTING.md](docs/TESTING.md)
 
 ---
 

--- a/apps/api/prisma/migrations/20251001090000_init/migration.sql
+++ b/apps/api/prisma/migrations/20251001090000_init/migration.sql
@@ -1,0 +1,86 @@
+-- Prisma Migration: Initial schema for Tenant, Influencer, Dataset, Job, Asset
+
+-- CreateTable Tenant
+CREATE TABLE "Tenant" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "Tenant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable Influencer
+CREATE TABLE "Influencer" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "persona" JSONB NOT NULL,
+    "datasetId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "Influencer_pkey" PRIMARY KEY ("id")
+);
+
+-- Indexes for Influencer
+CREATE INDEX "Influencer_tenantId_idx" ON "Influencer"("tenantId");
+
+-- CreateTable Dataset
+CREATE TABLE "Dataset" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "path" TEXT NOT NULL,
+    "meta" JSONB NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "Dataset_pkey" PRIMARY KEY ("id")
+);
+
+-- Indexes for Dataset
+CREATE INDEX "Dataset_tenantId_idx" ON "Dataset"("tenantId");
+
+-- CreateTable Job
+CREATE TABLE "Job" (
+    "id" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "payload" JSONB NOT NULL,
+    "result" JSONB,
+    "costTok" INTEGER,
+    "startedAt" TIMESTAMP(3),
+    "finishedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "Job_pkey" PRIMARY KEY ("id")
+);
+
+-- Indexes for Job
+CREATE INDEX "Job_status_idx" ON "Job"("status");
+CREATE INDEX "Job_type_idx" ON "Job"("type");
+
+-- CreateTable Asset
+CREATE TABLE "Asset" (
+    "id" TEXT NOT NULL,
+    "jobId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "meta" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "Asset_pkey" PRIMARY KEY ("id")
+);
+
+-- Indexes for Asset
+CREATE INDEX "Asset_jobId_idx" ON "Asset"("jobId");
+
+-- Foreign keys
+ALTER TABLE "Influencer" ADD CONSTRAINT "Influencer_tenantId_fkey"
+  FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Dataset" ADD CONSTRAINT "Dataset_tenantId_fkey"
+  FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Asset" ADD CONSTRAINT "Asset_jobId_fkey"
+  FOREIGN KEY ("jobId") REFERENCES "Job"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/apps/api/prisma/migrations/migration_lock.toml
+++ b/apps/api/prisma/migrations/migration_lock.toml
@@ -1,0 +1,2 @@
+provider = "postgresql"
+

--- a/backlog/issues.yaml
+++ b/backlog/issues.yaml
@@ -804,13 +804,13 @@ issues:
 
     ### DoD
 
-    - [ ] `docs/SETUP.md` creato con guida completa (prerequisiti, clone, Docker, DB, .env).
+    - [x] `docs/SETUP.md` creato con guida completa (prerequisiti, clone, Docker, DB, .env).
 
-    - [ ] `docs/TESTING.md` con istruzioni per eseguire test.
+    - [x] `docs/TESTING.md` con istruzioni per eseguire test.
 
-    - [ ] Script PowerShell documentati in `scripts/README.md`.
+    - [x] Script PowerShell documentati in `scripts/README.md`.
 
-    - [ ] Sezione troubleshooting con problemi comuni.
+    - [x] Sezione troubleshooting con problemi comuni.
 
 
     ### Dipendenze

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,132 @@
+# Setup Ambiente di Sviluppo
+
+Questa guida spiega come avviare l’intero stack in locale su Windows, macOS e Linux, con particolare attenzione a Windows/PowerShell.
+
+## Prerequisiti
+
+- Docker Desktop (o Docker Engine) con Docker Compose v2 disponibile come `docker compose`.
+  - Windows: abilita backend WSL 2 e il supporto a file sharing della cartella del repo.
+- Node.js 20+ e pnpm 9+ installati e nel PATH.
+- Git installato.
+- Facoltativi ma utili:
+  - GitHub CLI `gh` (per script utility).
+  - FFmpeg (per pipeline media locali, opzionale).
+
+## Clonare il repository
+
+```bash
+git clone <URL_DEL_REPO> influencerai-monorepo
+cd influencerai-monorepo
+```
+
+## Variabili d’ambiente
+
+- Copia il file `.env.example` in `.env` alla radice del repo e, se necessario, modifica i valori:
+
+```bash
+cp .env.example .env   # macOS/Linux
+# oppure
+copy .env.example .env # Windows PowerShell
+```
+
+Valori predefiniti utili (estratto):
+
+```
+DATABASE_URL=postgresql://postgres:postgres@postgres:5432/influencerai
+REDIS_URL=redis://redis:6379
+S3_ENDPOINT=http://minio:9000
+S3_KEY=minio
+S3_SECRET=minio12345
+S3_BUCKET=assets
+OPENROUTER_API_KEY=...
+```
+
+## Avvio rapido (consigliato)
+
+- macOS/Linux (Bash):
+
+```bash
+bash scripts/start-all.sh
+```
+
+- Windows (PowerShell):
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/start-all.ps1
+```
+
+Il comando costruisce e avvia tramite `infra/docker-compose.yml` i servizi: Postgres, Redis, MinIO, n8n, API, worker e Web UI. Se `.env` non esiste, viene creato a partire da `.env.example`.
+
+Endpoint utili dopo l’avvio:
+- Web UI: `http://localhost:3000`
+- API Swagger: `http://localhost:3001/api`
+- n8n: `http://localhost:5678`
+- MinIO Console: `http://localhost:9001` (S3 su `http://localhost:9000`)
+
+## Migrazioni database (Prisma)
+
+Le migrazioni richiedono il DB attivo (Postgres via Docker). Usa gli script dedicati:
+
+- Windows (PowerShell):
+
+```powershell
+# sincronizza schema (sviluppo)
+powershell -ExecutionPolicy Bypass -File scripts/db-migrate.ps1 -Action push
+
+# applica migrazioni (prod/staging)
+powershell -ExecutionPolicy Bypass -File scripts/db-migrate.ps1 -Action deploy
+```
+
+- macOS/Linux (Bash):
+
+```bash
+# sincronizza schema (sviluppo)
+bash scripts/db-migrate.sh push
+
+# applica migrazioni (prod/staging)
+bash scripts/db-migrate.sh deploy
+```
+
+Per verificare la connessione al DB:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/db-test.ps1
+```
+
+## Installazione dipendenze workspace
+
+Esegui nel root del repo dopo il primo clone o dopo aver aggiornato i pacchetti:
+
+```bash
+pnpm -w install
+```
+
+## Avvio dei singoli servizi (avanzato)
+
+Se vuoi gestire manualmente i servizi Docker:
+
+```bash
+cd infra
+docker compose up -d        # avvia
+docker compose logs -f api  # segui i log di un servizio
+docker compose down         # stop
+```
+
+## Troubleshooting
+
+- Verifica log: `cd infra && docker compose logs -f api` (o `web`, `worker`, `postgres`, `redis`, `minio`, `n8n`).
+- Ricostruzione forzata: `cd infra && docker compose build --no-cache && docker compose up -d`.
+- Volumi corrotti/schema incoerente: stop con purge e ripartenza
+  - PowerShell: `powershell -ExecutionPolicy Bypass -File scripts/stop-all.ps1 --purge`
+  - Bash: `bash scripts/stop-all.sh --purge`
+- `.env` mancante: crea a partire da `.env.example` o modifica i valori necessari.
+- Porte occupate: chiudi i processi che usano le porte o modifica il mapping in `infra/docker-compose.yml`.
+- Windows/PowerShell: se gli script sono bloccati, avvia la shell come amministratore oppure usa `-ExecutionPolicy Bypass` come mostrato.
+- WSL2: assicurati che Docker Desktop usi backend WSL 2 e che la cartella del progetto sia accessibile (evita percorsi di rete lenti).
+
+## Requisiti opzionali per pipeline AI locali
+
+- ComfyUI installato localmente per pipeline immagini/video.
+- FFmpeg nel PATH per elaborazioni video/audio.
+- GPU con driver aggiornati; se VRAM è limitata, riduci risoluzione/batch.
+

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,50 @@
+# Testing
+
+Istruzioni per eseguire test e verifiche locali del progetto.
+
+## Prerequisiti
+
+- Dipendenze installate: `pnpm -w install`
+- Servizi di base in esecuzione (per test d’integrazione DB): `bash scripts/start-all.sh` oppure PowerShell equivalente.
+
+## Test unitari e di pacchetto
+
+Il workspace è predisposto per usare `turbo` come orchestratore di comandi. Quando i pacchetti esporranno lo script `test` (es. con Vitest), potrai eseguire:
+
+```bash
+pnpm test
+# equivalente a
+turbo run test
+```
+
+Esecuzione selettiva per package (una volta presenti gli script `test`):
+
+```bash
+pnpm --filter @influencerai/core-schemas test
+pnpm --filter @influencerai/sdk test
+pnpm --filter @influencerai/prompts test
+```
+
+Nota: la configurazione Vitest e le suite test per `core-schemas`, `sdk`, `prompts` saranno introdotte nell’attività PKG-01.
+
+## Test con il database (smoke)
+
+Verifica rapida della connessione Postgres tramite Prisma:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/db-test.ps1
+```
+
+## Lint e build
+
+```bash
+pnpm lint
+pnpm build
+```
+
+## Troubleshooting test
+
+- Assicurati che `DATABASE_URL` sia valorizzata in `.env` o `apps/api/.env` per i test d’integrazione.
+- Se i servizi non sono disponibili, avviali con `scripts/start-all.{sh,ps1}`.
+- In caso di errori di permessi su Windows, esegui PowerShell con `-ExecutionPolicy Bypass`.
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,81 @@
+# Script di utilità
+
+Raccolta degli script disponibili nella cartella `scripts/` con esempi di utilizzo.
+
+## Requisiti comuni
+
+- Docker e Docker Compose v2 (`docker compose`).
+- Node.js 20+ e `pnpm` nel PATH (per script che richiedono il workspace).
+- Facoltativi: GitHub CLI `gh` per script che interagiscono con GitHub.
+
+Suggerimento Windows: esegui PowerShell con `-ExecutionPolicy Bypass` come mostrato negli esempi.
+
+---
+
+## Avvio/Stop stack
+
+- Avvio completo dello stack (DB, Redis, MinIO, n8n, API, worker, web):
+
+```bash
+# macOS/Linux
+bash scripts/start-all.sh
+
+# Windows
+powershell -ExecutionPolicy Bypass -File scripts/start-all.ps1
+```
+
+- Stop stack (con opzione di purge volumi):
+
+```bash
+# macOS/Linux
+bash scripts/stop-all.sh            # conserva volumi
+bash scripts/stop-all.sh --purge    # rimuove anche i volumi
+
+# Windows
+powershell -ExecutionPolicy Bypass -File scripts/stop-all.ps1           \
+  # conserva volumi
+powershell -ExecutionPolicy Bypass -File scripts/stop-all.ps1 --purge   \
+  # rimuove anche i volumi
+```
+
+---
+
+## Database (Prisma)
+
+- Migrazioni/schema:
+
+```bash
+# macOS/Linux
+bash scripts/db-migrate.sh push    # sincronizza schema (sviluppo)
+bash scripts/db-migrate.sh deploy  # applica migrazioni (prod/staging)
+
+# Windows
+powershell -ExecutionPolicy Bypass -File scripts/db-migrate.ps1 -Action push
+powershell -ExecutionPolicy Bypass -File scripts/db-migrate.ps1 -Action deploy
+```
+
+- Test connessione DB (smoke):
+
+```bash
+# Windows (PowerShell)
+powershell -ExecutionPolicy Bypass -File scripts/db-test.ps1
+```
+
+Note:
+- Richiede `DATABASE_URL` in `.env` (root) o `apps/api/.env`.
+- Richiede `pnpm` disponibile nel PATH.
+
+---
+
+## GitHub issue helper
+
+Spunta automaticamente tutti i checkbox di un’issue su GitHub (richiede `gh` configurato):
+
+```bash
+# macOS/Linux
+bash scripts/update-issue-checklist.sh 123
+
+# Windows
+powershell -ExecutionPolicy Bypass -File scripts/update-issue-checklist.ps1 -IssueNumber 123
+```
+


### PR DESCRIPTION
Contesto
Aggiunte migrazioni iniziali per gli schemi Tenant, Influencer, Dataset, Job, Asset in linea con apps/api/prisma/schema.prisma:1.
Abilitato il job api-migrate in infra/docker-compose.yml:62 a completare correttamente in deploy.
Cosa cambia
Commit in repo delle migrazioni Prisma (prima erano ignorate).
Migrazione SQL iniziale con indici e vincoli FK a cascata.
DoD (INFRA-01)
 Migrazione iniziale generata e commit in apps/api/prisma/migrations/.
 Tabelle: Tenant, Influencer, Dataset, Job, Asset.
 docker compose up api-migrate eseguibile.
Come testare
cd infra && docker compose up -d postgres redis minio
docker compose up --build api-migrate → deve concludere con exit 0.
Verifica DB: powershell -ExecutionPolicy Bypass -File scripts/db-test.ps1 oppure bash scripts/db-migrate.sh deploy.
Rischi/rollback
Basso: solo aggiunta schema iniziale. Rollback eliminando migrazione e ricostruendo il volume Postgres.