### PR TITLE
API-04: Content Plans skeleton (controller/service/DTO + e2e)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,10 @@
       "Bash(docker compose:*)",
       "Bash(gh issue create:*)",
       "Bash(gh issue edit 4 --body \"$(cat <<''EOF''\n### Contesto\nLo schema Prisma con modelli Tenant, Influencer, Dataset, Job e Asset è già definito in `apps/api/prisma/schema.prisma`. Le migrazioni Prisma devono essere generate e applicate per creare effettivamente le tabelle nel database PostgreSQL. Gli script di generazione del client devono essere integrati nel workflow di sviluppo.\n\n### Stato Attuale\n- ✅ schema.prisma implementato con tutti i modelli richiesti\n- ❌ Nessuna migrazione generata in `apps/api/prisma/migrations/`\n- ❌ Database non inizializzato\n- ❌ Procedura di migrazione non documentata nella README API\n\n### DoD\n- [ ] Migrazione iniziale generata con `cd apps/api && pnpm dlx prisma migrate dev --name init`\n- [ ] Tabelle create e verificate nel database Postgres locale\n- [ ] Script `prisma:generate` verificato in `apps/api/package.json`\n- [ ] Documentata nella README API la procedura per applicare le migrazioni\n- [ ] Verificato che `docker compose up api` completa con successo dopo migrate\n\n### Dipendenze\n- [INFRA-01] Inizializzare database con Prisma migrations\n\n### Note Tecniche\nLo schema include:\n- Multi-tenancy via `Tenant` con cascade delete\n- `Influencer` con `persona` JSON e link opzionale a dataset\n- `Dataset` con `meta` JSON per training LoRA\n- `Job` con tracking costi token OpenRouter (`costTok`)\n- `Asset` per storage output generati (immagini/video)\n- Indici su relazioni e query frequenti (status, type, tenantId)\nEOF\n)\")",
-      "Bash(gh issue view:*)"
+      "Bash(gh issue view:*)",
+      "Bash(npx eslint:*)",
+      "Bash(cat:*)",
+      "Bash(git check-ignore:*)"
     ],
     "deny": [],
     "ask": []

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,8 @@
     "prisma:db:push": "prisma db push"
   },
   "dependencies": {
+    "@influencerai/core-schemas": "workspace:*",
+    "@influencerai/prompts": "workspace:*",
     "@fastify/static": "^7.0.4",
     "@nestjs/bullmq": "^10.2.1",
     "@nestjs/common": "^10.4.8",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,10 +1,11 @@
-﻿import { Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PrismaModule } from './prisma/prisma.module';
 import { BullModule } from '@nestjs/bullmq';
 import { JobsModule } from './jobs/jobs.module';
+import { ContentPlansModule } from './content-plans/content-plans.module';
 
 function parseRedisUrl(url?: string) {
   try {
@@ -31,8 +32,10 @@ const extraImports = enableBull
     PrismaModule,
     ...extraImports,
     JobsModule,
+    ContentPlansModule,
   ],
   controllers: [AppController],
   providers: [AppService],
 })
 export class AppModule {}
+

--- a/apps/api/src/content-plans/content-plans.controller.ts
+++ b/apps/api/src/content-plans/content-plans.controller.ts
@@ -1,0 +1,44 @@
+import { BadRequestException, Controller, Get, NotFoundException, Param, Post, Body, Query } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ContentPlansService } from './content-plans.service';
+import { CreateContentPlanSchema, ListPlansQuerySchema } from './dto';
+
+@ApiTags('content-plans')
+@Controller('content-plans')
+export class ContentPlansController {
+  constructor(private readonly svc: ContentPlansService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Generate and persist a content plan' })
+  @ApiResponse({ status: 201, description: 'Content plan created' })
+  create(@Body() body: unknown) {
+    const parsed = CreateContentPlanSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new BadRequestException(parsed.error.flatten());
+    }
+    return this.svc.createPlan(parsed.data);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get content plan by id' })
+  async get(@Param('id') id: string) {
+    const res = await this.svc.getPlan(id);
+    if (!res) throw new NotFoundException('Content plan not found');
+    return res;
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List content plans' })
+  list(
+    @Query('influencerId') influencerId?: string,
+    @Query('take') take?: string,
+    @Query('skip') skip?: string,
+  ) {
+    const parsed = ListPlansQuerySchema.safeParse({ influencerId, take, skip });
+    if (!parsed.success) {
+      throw new BadRequestException(parsed.error.flatten());
+    }
+    return this.svc.listPlans(parsed.data);
+  }
+}
+

--- a/apps/api/src/content-plans/content-plans.module.ts
+++ b/apps/api/src/content-plans/content-plans.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ContentPlansController } from './content-plans.controller';
+import { ContentPlansService } from './content-plans.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Module({
+  controllers: [ContentPlansController],
+  providers: [PrismaService, ContentPlansService],
+})
+export class ContentPlansModule {}
+

--- a/apps/api/src/content-plans/content-plans.service.ts
+++ b/apps/api/src/content-plans/content-plans.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateContentPlanDto, ContentPlanResponse } from './dto';
+
+// Minimal local prompt to avoid build coupling; align with @influencerai/prompts
+function contentPlanPrompt(persona: string, theme: string) {
+  return `You are helping create a content plan for a virtual influencer with the following persona:\n${persona}\n\nTheme: ${theme}\n\nGenerate 3-5 post ideas with captions and hashtags suitable for Instagram, TikTok, and YouTube Shorts.\nReturn the response as a JSON array with this structure:\n[ { \"caption\": \"engaging caption text\", \"hashtags\": [\"tag1\", \"tag2\"] } ]`;
+}
+
+@Injectable()
+export class ContentPlansService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // Extracted so tests can mock only this part
+  async generatePlanPosts(persona: string, theme: string): Promise<{ caption: string; hashtags: string[] }[]> {
+    const prompt = contentPlanPrompt(persona, theme);
+    const apiKey = process.env.OPENROUTER_API_KEY || '';
+    const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'openrouter/auto',
+        messages: [
+          { role: 'system', content: 'You are a helpful assistant that returns strict JSON.' },
+          { role: 'user', content: prompt },
+        ],
+        response_format: { type: 'json_object' },
+      }),
+    });
+    const data = (await res.json()) as any;
+    // Defensive parsing depending on provider; expect JSON array in content
+    const text: string = data?.choices?.[0]?.message?.content || '[]';
+    let posts: any = [];
+    try { posts = JSON.parse(text); } catch { posts = []; }
+    if (!Array.isArray(posts)) posts = [];
+    // normalize
+    return posts.map((p: any) => ({ caption: String(p.caption || ''), hashtags: Array.isArray(p.hashtags) ? p.hashtags.map(String) : [] }));
+  }
+
+  async createPlan(input: CreateContentPlanDto): Promise<{ id: string; plan: ContentPlanResponse }> {
+    const infl = await this.prisma.influencer.findUnique({ where: { id: input.influencerId } });
+    if (!infl) throw new NotFoundException('Influencer not found');
+
+    const posts = await this.generatePlanPosts(JSON.stringify(infl.persona ?? {}), input.theme);
+    const createdAt = new Date().toISOString();
+    const plan: ContentPlanResponse = {
+      influencerId: input.influencerId,
+      theme: input.theme,
+      targetPlatforms: input.targetPlatforms ?? ['instagram'],
+      posts,
+      createdAt,
+    };
+
+    const job = await this.prisma.job.create({
+      data: {
+        type: 'content-plan' as any,
+        status: 'completed',
+        payload: { influencerId: input.influencerId, theme: input.theme, targetPlatforms: plan.targetPlatforms } as any,
+        result: plan as any,
+        finishedAt: new Date(),
+      },
+    });
+
+    return { id: job.id, plan };
+  }
+
+  async getPlan(id: string): Promise<{ id: string; plan: ContentPlanResponse } | null> {
+    const job = await this.prisma.job.findUnique({ where: { id } });
+    if (!job || job.type !== ('content-plan' as any)) return null;
+    const plan = (job.result as any) as ContentPlanResponse;
+    return { id: job.id, plan };
+  }
+
+  async listPlans(params: { influencerId?: string; take?: number; skip?: number }): Promise<{ id: string; plan: ContentPlanResponse }[]> {
+    const jobs = await this.prisma.job.findMany({
+      where: {
+        type: 'content-plan' as any,
+        ...(params.influencerId ? { payload: { path: ['influencerId'], equals: params.influencerId } as any } : {}),
+      },
+      orderBy: { createdAt: 'desc' },
+      take: params.take ?? 20,
+      skip: params.skip ?? 0,
+    });
+    return jobs.map((j: any) => ({ id: j.id, plan: (j.result as any) as ContentPlanResponse }));
+  }
+}

--- a/apps/api/src/content-plans/dto.ts
+++ b/apps/api/src/content-plans/dto.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const CreateContentPlanSchema = z.object({
+  influencerId: z.string().min(1),
+  theme: z.string().min(1),
+  targetPlatforms: z.array(z.enum(['instagram', 'tiktok', 'youtube'])).default(['instagram']).optional(),
+});
+
+export type CreateContentPlanDto = z.infer<typeof CreateContentPlanSchema>;
+
+// Response shape aligns with ContentPlan but with server-generated createdAt
+export const ContentPlanResponseSchema = z.object({
+  influencerId: z.string(),
+  theme: z.string(),
+  targetPlatforms: z.array(z.enum(['instagram', 'tiktok', 'youtube'])),
+  posts: z.array(
+    z.object({ caption: z.string(), hashtags: z.array(z.string()) })
+  ),
+  createdAt: z.string().datetime(),
+});
+export type ContentPlanResponse = z.infer<typeof ContentPlanResponseSchema>;
+
+export const ListPlansQuerySchema = z.object({
+  influencerId: z.string().min(1).optional(),
+  take: z.coerce.number().int().min(1).max(100).default(20).optional(),
+  skip: z.coerce.number().int().min(0).default(0).optional(),
+});
+
+export type ListPlansQuery = z.infer<typeof ListPlansQuerySchema>;

--- a/apps/api/test/content-plans.e2e-spec.ts
+++ b/apps/api/test/content-plans.e2e-spec.ts
@@ -1,0 +1,75 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import * as supertest from 'supertest';
+import { AppModule } from '../src/app.module';
+import { ContentPlansService } from '../src/content-plans/content-plans.service';
+import { PrismaService } from '../src/prisma/prisma.service';
+
+describe('Content Plans (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    const svcMock: Partial<ContentPlansService> = {
+      createPlan: jest.fn(async (dto: any) => ({
+        id: 'cp_1',
+        plan: {
+          influencerId: dto.influencerId,
+          theme: dto.theme,
+          targetPlatforms: dto.targetPlatforms ?? ['instagram'],
+          posts: [ { caption: 'Hello world', hashtags: ['hi'] } ],
+          createdAt: new Date().toISOString(),
+        },
+      })),
+      getPlan: jest.fn(async (id: string) => ({
+        id,
+        plan: ({
+          influencerId: 'inf_1',
+          theme: 'tech',
+          targetPlatforms: ['instagram'],
+          posts: [{ caption: 'c', hashtags: [] as string[] }],
+          createdAt: new Date().toISOString(),
+        } as any),
+      })),
+      listPlans: jest.fn(async () => ([{
+        id: 'cp_1',
+        plan: ({ influencerId: 'inf_1', theme: 'tech', targetPlatforms: ['instagram'], posts: [{ caption: 'c', hashtags: [] as string[] }], createdAt: new Date().toISOString() } as any)
+      }]))
+    };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(ContentPlansService).useValue(svcMock)
+      .overrideProvider(PrismaService).useValue({ onModuleInit: jest.fn(), onModuleDestroy: jest.fn(), enableShutdownHooks: jest.fn() })
+      .compile();
+
+    app = moduleFixture.createNestApplication(new FastifyAdapter());
+    await app.init();
+    await (app.getHttpAdapter().getInstance() as any).ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('POST /content-plans creates a plan', async () => {
+    const res = await (supertest as any)(app.getHttpServer())
+      .post('/content-plans')
+      .send({ influencerId: 'inf_1', theme: 'tech' })
+      .expect(201);
+    expect(res.body.id).toBe('cp_1');
+    expect(res.body.plan).toBeTruthy();
+  });
+
+  it('GET /content-plans lists plans', async () => {
+    const res = await (supertest as any)(app.getHttpServer()).get('/content-plans').expect(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('GET /content-plans/:id returns a plan', async () => {
+    const res = await (supertest as any)(app.getHttpServer()).get('/content-plans/cp_1').expect(200);
+    expect(res.body.id).toBe('cp_1');
+  });
+});


### PR DESCRIPTION
- Aggiunge modulo Content Plans con DTO Zod, controller e service\n- POST /content-plans: genera piano (mockabile) e persiste su Job (type 'content-plan')\n- GET /content-plans e GET /content-plans/:id\n- Test e2e con service mock (senza chiamare OpenRouter)\n- Modulo registrato in AppModule\n- Dipendenze workspace aggiunte (non richieste a runtime nel test)\n\nNota: persistenza provvisoria su Job per evitare nuova migrazione prisma; in una fase successiva si può aggiungere un modello ContentPlan dedicato con relazioni a Influencer/Tenant.