### PR TITLE
API-04: Complete acceptance (OpenRouter stub test, tenant association)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,9 @@
       "Bash(gh issue view:*)",
       "Bash(npx eslint:*)",
       "Bash(cat:*)",
-      "Bash(git check-ignore:*)"
+      "Bash(git check-ignore:*)",
+      "Bash(gh label list:*)",
+      "Bash(gh label create:*)"
     ],
     "deny": [],
     "ask": []

--- a/apps/api/src/content-plans/content-plans.service.spec.ts
+++ b/apps/api/src/content-plans/content-plans.service.spec.ts
@@ -1,0 +1,29 @@
+import { ContentPlansService } from './content-plans.service';
+
+describe('ContentPlansService', () => {
+  const prismaMock: any = {
+    influencer: { findUnique: jest.fn() },
+    job: { create: jest.fn() },
+  };
+
+  beforeEach(() => {
+    // Configure prisma mocks
+    prismaMock.influencer.findUnique.mockImplementation(async ({ where: { id } }: any) => (id === 'inf_1' ? { id, tenantId: 'ten_1', persona: { name: 'A' } } : null));
+    prismaMock.job.create.mockImplementation(async ({ data }: any) => ({ id: 'job_cp_1', ...data }));
+    // Mock global fetch to simulate OpenRouter returning JSON array in content
+    global.fetch = jest.fn(async () => ({
+      json: async () => ({ choices: [{ message: { content: JSON.stringify([{ caption: 'post1', hashtags: ['x'] }]) } }] }),
+    })) as any;
+  });
+
+  it('createPlan parses posts and persists job with influencer/tenant association', async () => {
+    const svc = new ContentPlansService(prismaMock);
+    const res = await svc.createPlan({ influencerId: 'inf_1', theme: 't' });
+    expect(res.id).toBe('job_cp_1');
+    expect(res.plan.posts[0]).toEqual({ caption: 'post1', hashtags: ['x'] });
+    expect(prismaMock.job.create).toHaveBeenCalled();
+    const arg = prismaMock.job.create.mock.calls[0][0];
+    expect(arg.data.payload).toMatchObject({ influencerId: 'inf_1', tenantId: 'ten_1' });
+    expect(arg.data.result.createdAt).toBeTruthy();
+  });
+});

--- a/apps/api/src/content-plans/content-plans.service.ts
+++ b/apps/api/src/content-plans/content-plans.service.ts
@@ -58,7 +58,7 @@ export class ContentPlansService {
       data: {
         type: 'content-plan' as any,
         status: 'completed',
-        payload: { influencerId: input.influencerId, theme: input.theme, targetPlatforms: plan.targetPlatforms } as any,
+        payload: { influencerId: input.influencerId, tenantId: infl.tenantId, theme: input.theme, targetPlatforms: plan.targetPlatforms } as any,
         result: plan as any,
         finishedAt: new Date(),
       },


### PR DESCRIPTION
- POST /content-plans: integrazione OpenRouter (stub nei test) usando persona da Influencer\n- Persistenza con timestamp in Job.result e associazione a influencer/tenant nel payload (tenantId incluso)\n- GET /content-plans e GET /content-plans/:id già operativi\n- Test unit: mock fetch e verifica prisma.job.create (parsing + salvataggio)\n\nNota: persistenza su Job come ponte; modello ContentPlan dedicato può seguire in una migrazione successiva.