### PR TITLE
fix: import vitest globals in login test

### DIFF
--- a/apps/web/src/__tests__/login.test.tsx
+++ b/apps/web/src/__tests__/login.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import LoginPage from "../app/login/page";
 


### PR DESCRIPTION
## Summary
- add an explicit import for Vitest helpers in the login page test so eslint recognizes the globals

## Testing
- `pnpm lint` *(fails: existing lint errors in apps/api unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68de54e87e588320aa5757b003e70f2b