### PR TITLE
chore(web): configure vitest setup with jest-dom

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:watch": "vitest watch"
   },
   "dependencies": {
     "next": "^15.1.4",

--- a/apps/web/src/__tests__/home.test.tsx
+++ b/apps/web/src/__tests__/home.test.tsx
@@ -1,7 +1,23 @@
-import { describe, it, expect } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import Home from "../app/page";
 
-describe("home placeholder", () => {
-  it("runs", () => {
-    expect(1 + 1).toBe(2);
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: vi.fn(),
+  }),
+}));
+
+describe("Home page", () => {
+  it("renders the dashboard headline and description", () => {
+    render(<Home />);
+
+    expect(
+      screen.getByRole("heading", { name: /influencerai dashboard/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/virtual influencer content generation platform/i)
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React from "react";
 import { useRouter } from "next/navigation";
 
 export default function Home() {

--- a/apps/web/src/setupTests.ts
+++ b/apps/web/src/setupTests.ts
@@ -1,1 +1,1 @@
-﻿import '@testing-library/jest-dom';
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- configure the shared test setup to use the Vitest-specific jest-dom entrypoint
- exercise the home page through Testing Library to assert rendered UI copy
- add a test:watch script for the web package for easier local development

## Testing
- pnpm --filter @influencerai/web test

------
https://chatgpt.com/codex/tasks/task_e_68dffe12a9a883209f144b5346015b66