### PR TITLE
WEB-03: ensure Vitest setup loads jest-dom matchers

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:watch": "vitest watch"
   },
   "dependencies": {
     "next": "^15.1.4",

--- a/apps/web/src/__tests__/home.test.tsx
+++ b/apps/web/src/__tests__/home.test.tsx
@@ -1,7 +1,23 @@
-import { describe, it, expect } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
-describe("home placeholder", () => {
-  it("runs", () => {
-    expect(1 + 1).toBe(2);
+import Home from "../app/page";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+describe("Home", () => {
+  it("renders dashboard heading and logout button", () => {
+    render(<Home />);
+
+    expect(
+      screen.getByRole("heading", { name: /influencerai dashboard/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /logout/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(/virtual influencer content generation platform/i)
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/__tests__/login.test.tsx
+++ b/apps/web/src/__tests__/login.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
 import LoginPage from "../app/login/page";
 
 vi.mock("next/navigation", () => ({
@@ -10,12 +11,24 @@ vi.mock("next/navigation", () => ({
 
 describe("LoginPage", () => {
   beforeEach(() => {
-    const mockFetch = vi.fn(async () => ({ ok: true, json: async () => ({ ok: true }) }));
+    const mockFetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ ok: true }),
+    }));
     globalThis.fetch = mockFetch as unknown as typeof fetch;
   });
 
-  it("renders form and submits", async () => {
+  it("renders form fields", () => {
     render(<LoginPage />);
+
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  it("submits credentials", async () => {
+    render(<LoginPage />);
+
     const email = screen.getByLabelText(/email/i);
     const password = screen.getByLabelText(/password/i);
     const submit = screen.getByRole("button", { name: /sign in/i });

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React from "react";
 import { useRouter } from "next/navigation";
 
 export default function Home() {

--- a/apps/web/src/setupTests.ts
+++ b/apps/web/src/setupTests.ts
@@ -1,1 +1,1 @@
-﻿import '@testing-library/jest-dom';
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- ensure the shared setup file imports @testing-library/jest-dom matchers
- expand home and login tests to render actual pages and assert DOM behavior
- add a test:watch script and adjust the home page module to satisfy the test runtime

## Testing
- pnpm --filter @influencerai/web test

------
https://chatgpt.com/codex/tasks/task_e_68dffe12a9a883209f144b5346015b66