### PR TITLE
Ensure Turbo builds install dependencies first

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "turbo run dev",
+    "prebuild": "pnpm install --frozen-lockfile",
     "build": "turbo run build",
     "test": "turbo run test",
     "lint": "turbo run lint",


### PR DESCRIPTION
## Summary
- add a prebuild script so that `pnpm install --frozen-lockfile` runs before invoking Turbo builds

## Testing
- pnpm run build --filter=@influencerai/web *(fails: Next.js ESLint errors from existing test file)*

------
https://chatgpt.com/codex/tasks/task_e_68e00e2d0dd08320950a94e21f265839