### PR TITLE
Fix Vitest globals configuration in ESLint

### DIFF
--- a/apps/web/eslint.config.cjs
+++ b/apps/web/eslint.config.cjs
@@ -10,4 +10,24 @@ module.exports = [
   { ignores: ['.next/**', 'node_modules/**', 'dist/**'] },
   js.configs.recommended,
   ...nextCoreWebVitals,
+  {
+    files: [
+      'src/**/*.test.{js,jsx,ts,tsx}',
+      'src/**/*.spec.{js,jsx,ts,tsx}',
+      'src/__tests__/**/*.{js,jsx,ts,tsx}',
+    ],
+    languageOptions: {
+      globals: {
+        describe: 'readonly',
+        it: 'readonly',
+        expect: 'readonly',
+        test: 'readonly',
+        vi: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+      },
+    },
+  },
 ]


### PR DESCRIPTION
## Summary
- allow ESLint to recognize Vitest globals within test files
- target common test file patterns so describe/it/expect no longer trigger no-undef errors

## Testing
- pnpm --filter @influencerai/web lint

------
https://chatgpt.com/codex/tasks/task_e_68e00f86659483209ab100cda50b0a98