### PR TITLE
Fix vitest globals in home test

### DIFF
--- a/apps/web/src/__tests__/home.test.tsx
+++ b/apps/web/src/__tests__/home.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import Home from "../app/page";
 
 vi.mock("next/navigation", () => ({


### PR DESCRIPTION
## Summary
- import the vitest test globals used by the home page test to satisfy eslint

## Testing
- pnpm --filter @influencerai/web lint

------
https://chatgpt.com/codex/tasks/task_e_68e00f86659483209ab100cda50b0a98