### PR TITLE
test: expand sdk client coverage

### DIFF
--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -2,13 +2,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { InfluencerAIClient } from '../src';
 import { InfluencerAIAPIError } from '../src';
+import * as fetchUtils from '../src/fetch-utils';
 
 describe('InfluencerAIClient error handling', () => {
   const realFetch = globalThis.fetch;
   const client = new InfluencerAIClient('https://api.test.example');
+  const jsonResponse = (body: unknown) =>
+    new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+
+  let fetchWithTimeoutSpy: ReturnType<typeof vi.spyOn<typeof fetchUtils, 'fetchWithTimeout'>>;
+  let handleResponseSpy: ReturnType<typeof vi.spyOn<typeof fetchUtils, 'handleResponse'>>;
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    globalThis.fetch = realFetch;
+    fetchWithTimeoutSpy = vi.spyOn(fetchUtils, 'fetchWithTimeout');
+    handleResponseSpy = vi.spyOn(fetchUtils, 'handleResponse');
   });
 
   afterEach(() => {
@@ -16,17 +25,14 @@ describe('InfluencerAIClient error handling', () => {
   });
 
   it('createJob returns parsed JSON on success', async () => {
-    const res = new Response(JSON.stringify({ id: 'j1' }), { status: 200, headers: { 'content-type': 'application/json' } });
+    const res = jsonResponse({ id: 'j1' });
     vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue(res as unknown as Response);
     const out = await client.createJob({} as any);
     expect(out).toEqual({ id: 'j1' });
   });
 
   it('createJob result is typed as JobResponse and id is accessible', async () => {
-    const res = new Response(JSON.stringify({ id: 'j-typed', status: 'pending' }), {
-      status: 200,
-      headers: { 'content-type': 'application/json' },
-    });
+    const res = jsonResponse({ id: 'j-typed', status: 'pending' });
     vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue(res as unknown as Response);
     const out = await client.createJob({} as any);
     // Access id without casting to ensure the type is present at compile time
@@ -35,10 +41,73 @@ describe('InfluencerAIClient error handling', () => {
     expect(out.status).toBe('pending');
   });
 
+  it('createJob throws InfluencerAIAPIError when response lacks id', async () => {
+    const response = {} as Response;
+    fetchWithTimeoutSpy.mockResolvedValue(response);
+    handleResponseSpy.mockResolvedValue({} as any);
+    await expect(client.createJob({} as any)).rejects.toBeInstanceOf(InfluencerAIAPIError as any);
+    expect(handleResponseSpy).toHaveBeenCalledWith(response);
+  });
+
   it('getJob throws InfluencerAIAPIError on non-OK', async () => {
-    const res = new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'content-type': 'application/json' } });
+    const res = new Response(JSON.stringify({ error: 'not found' }), {
+      status: 404,
+      headers: { 'content-type': 'application/json' },
+    });
     vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue(res as unknown as Response);
     await expect(client.getJob('missing')).rejects.toBeInstanceOf(InfluencerAIAPIError as any);
+  });
+
+  it('listJobs delegates to fetchWithTimeout and handleResponse', async () => {
+    const response = {} as Response;
+    fetchWithTimeoutSpy.mockResolvedValue(response);
+    handleResponseSpy.mockResolvedValue([{ id: 'job-1' }] as any);
+    const result = await client.listJobs();
+    expect(fetchWithTimeoutSpy).toHaveBeenCalledWith('https://api.test.example/jobs');
+    expect(fetchWithTimeoutSpy.mock.calls[0][1]).toBeUndefined();
+    expect(handleResponseSpy).toHaveBeenCalledWith(response);
+    expect(result).toEqual([{ id: 'job-1' }]);
+  });
+
+  it('updateJob sends PATCH with payload and returns handled response', async () => {
+    const response = {} as Response;
+    const update = { status: 'done' };
+    fetchWithTimeoutSpy.mockResolvedValue(response);
+    handleResponseSpy.mockResolvedValue({ ok: true } as any);
+    const result = await client.updateJob('job-42', update);
+    expect(fetchWithTimeoutSpy).toHaveBeenCalledWith('https://api.test.example/jobs/job-42', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(update),
+    });
+    expect(handleResponseSpy).toHaveBeenCalledWith(response);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('createContentPlan uses POST and returns handled response', async () => {
+    const response = {} as Response;
+    const plan = { title: 'Plan' } as any;
+    fetchWithTimeoutSpy.mockResolvedValue(response);
+    handleResponseSpy.mockResolvedValue({ id: 'plan-1' } as any);
+    const result = await client.createContentPlan(plan);
+    expect(fetchWithTimeoutSpy).toHaveBeenCalledWith('https://api.test.example/content-plans', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(plan),
+    });
+    expect(handleResponseSpy).toHaveBeenCalledWith(response);
+    expect(result).toEqual({ id: 'plan-1' });
+  });
+
+  it('health checks API status via fetchWithTimeout and handleResponse', async () => {
+    const response = {} as Response;
+    fetchWithTimeoutSpy.mockResolvedValue(response);
+    handleResponseSpy.mockResolvedValue({ status: 'ok' } as any);
+    const result = await client.health();
+    expect(fetchWithTimeoutSpy).toHaveBeenCalledWith('https://api.test.example/health');
+    expect(fetchWithTimeoutSpy.mock.calls[0][1]).toBeUndefined();
+    expect(handleResponseSpy).toHaveBeenCalledWith(response);
+    expect(result).toEqual({ status: 'ok' });
   });
 });
 


### PR DESCRIPTION
## Summary
- add a shared JSON response helper and spies for the fetch utilities in the client tests
- cover createJob error handling when an id is missing and ensure list/update/content-plan/health delegate correctly

## Testing
- pnpm --filter @influencerai/sdk test
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e0157f99e08320b3c4c2dff7d5e124