### PR TITLE
test(prompts): add vitest suite

### DIFF
--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -6,9 +6,12 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch"
   },
   "devDependencies": {
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.9"
   }
 }

--- a/packages/prompts/test/prompts.test.ts
+++ b/packages/prompts/test/prompts.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  contentPlanPrompt,
+  imageCaptionPrompt,
+  videoScriptPrompt,
+} from '../src';
+
+describe('prompts factories', () => {
+  it('contentPlanPrompt interpolates persona and theme and requests JSON array format', () => {
+    const persona = 'Galactic storyteller';
+    const theme = 'interstellar travel tips';
+
+    const prompt = contentPlanPrompt(persona, theme);
+
+    expect(prompt).toContain(persona);
+    expect(prompt).toContain(`Theme: ${theme}`);
+    expect(prompt).toContain('Return the response as a JSON array');
+    expect(prompt).toMatch(/\[\s*\{/);
+    expect(prompt).toContain('Generate 3-5 post ideas');
+  });
+
+  it('imageCaptionPrompt interpolates context and keeps bullet guidance', () => {
+    const context = 'sunset over neon city skyline';
+
+    const prompt = imageCaptionPrompt(context);
+
+    expect(prompt).toContain(`Context: ${context}`);
+    expect(prompt).toContain('- Subject appearance and pose');
+    expect(prompt).toContain('- Lighting and atmosphere');
+    expect(prompt).toContain('- Background and setting');
+    expect(prompt).toContain('- Style and mood');
+    expect(prompt).toContain('Provide a concise, detailed caption');
+  });
+
+  it('videoScriptPrompt interpolates caption and duration with bullet formatting', () => {
+    const caption = 'New product reveal livestream';
+    const duration = 45;
+
+    const prompt = videoScriptPrompt(caption, duration);
+
+    expect(prompt).toContain(`${duration}-second video script`);
+    expect(prompt).toContain(caption);
+    expect(prompt).toContain('- Opening hook (1-2 seconds)');
+    expect(prompt).toContain('- Main content beats');
+    expect(prompt).toContain('- Call to action');
+    expect(prompt).toContain('Format as timestamped beats');
+  });
+});

--- a/packages/prompts/tsconfig.vitest.json
+++ b/packages/prompts/tsconfig.vitest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  },
+  "include": ["src", "test"]
+}

--- a/packages/prompts/vitest.config.ts
+++ b/packages/prompts/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+    typecheck: {
+      tsconfig: './tsconfig.vitest.json',
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.2
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0)
 
   packages/sdk:
     dependencies:


### PR DESCRIPTION
## Summary
- add vitest and test scripts to the prompts package
- configure Vitest with a dedicated tsconfig for prompts
- cover the prompt factories with assertions about interpolation and formatting

## Testing
- pnpm --filter @influencerai/prompts test
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e0157bb8908320a6f79e885dc2d6b6