### PR TITLE
feat(web): enhance operational dashboard

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,21 +1,24 @@
 import { HealthCard } from "../../components/HealthCard";
-import { QueuesWidget } from "../../components/QueuesWidget";
 import { JobsChart } from "../../components/JobsChart";
+import { QueuesWidget } from "../../components/QueuesWidget";
 
 export default function DashboardPage() {
   return (
-    <main className="min-h-screen p-8 space-y-8">
-      <header>
-        <h1 className="text-3xl font-semibold">Operational Dashboard</h1>
-        <p className="text-gray-500">Stato code, servizi e job recenti</p>
-      </header>
-      <section className="grid gap-6 md:grid-cols-2">
-        <QueuesWidget />
-        <HealthCard />
-      </section>
-      <section>
-        <JobsChart />
-      </section>
+    <main className="min-h-screen bg-slate-50 p-6 md:p-10">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
+        <header className="space-y-2">
+          <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">Operations</p>
+          <h1 className="text-3xl font-bold text-slate-900">Operational Dashboard</h1>
+          <p className="text-slate-600">Stato code, servizi e job recenti per il team di contenuti virtuali.</p>
+        </header>
+        <section className="grid gap-6 lg:grid-cols-[1.2fr_1fr]">
+          <QueuesWidget />
+          <HealthCard />
+        </section>
+        <section>
+          <JobsChart />
+        </section>
+      </div>
     </main>
   );
 }

--- a/apps/web/src/components/HealthCard.tsx
+++ b/apps/web/src/components/HealthCard.tsx
@@ -1,36 +1,91 @@
-﻿"use client";
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
-type HealthResponse = { status: "ok" | "degraded" | "down"; checks: Record<string, boolean> };
+import { apiGet, ApiError } from "../lib/api";
 
-async function fetchHealth(): Promise<HealthResponse> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/healthz`, { cache: "no-store" });
-  if (!res.ok) throw new Error("Failed to fetch health");
-  return res.json();
+type HealthResponse = {
+  status: "ok" | "degraded" | "down";
+  checks: Record<string, boolean>;
+};
+
+const STATUS_CONFIG: Record<HealthResponse["status"], { label: string; badgeClass: string }> = {
+  ok: {
+    label: "Tutti i servizi operativi",
+    badgeClass: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  },
+  degraded: {
+    label: "Servizi con degrado",
+    badgeClass: "bg-amber-100 text-amber-700 border-amber-200",
+  },
+  down: {
+    label: "Servizi non disponibili",
+    badgeClass: "bg-red-100 text-red-700 border-red-200",
+  },
+};
+
+function ChecksSkeleton() {
+  return (
+    <div className="space-y-2">
+      {[0, 1, 2].map((index) => (
+        <div key={index} className="h-3 w-full animate-pulse rounded bg-slate-200" />
+      ))}
+    </div>
+  );
 }
 
 export function HealthCard() {
-  const { data, error, isLoading } = useQuery({
+  const { data, error, isLoading } = useQuery<HealthResponse, Error>({
     queryKey: ["health"],
-    queryFn: fetchHealth,
+    queryFn: () => apiGet<HealthResponse>("/healthz"),
     refetchInterval: 5000,
   });
 
+  const status = data ? STATUS_CONFIG[data.status] : undefined;
+  const checks = data ? Object.entries(data.checks) : [];
+
   return (
-    <div className="rounded-lg border p-4">
-      <h2 className="text-lg font-medium mb-2">Health</h2>
-      {isLoading && <p>Loading...</p>}
-      {error && <p className="text-red-600">Errore health</p>}
-      {data && (
+    <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <header className="flex items-start justify-between gap-3">
         <div>
-          <p className="mb-2">Stato: <span className="font-semibold">{data.status}</span></p>
-          <ul className="list-disc ml-5 text-sm text-gray-600">
-            {Object.entries(data.checks).map(([k, v]) => (
-              <li key={k}>{k}: {v ? "ok" : "down"}</li>
+          <h2 className="text-lg font-semibold text-slate-900">Health</h2>
+          <p className="text-sm text-slate-500">Aggregazione di healthz / readyz</p>
+        </div>
+        {status && (
+          <span className={`rounded-full border px-3 py-1 text-xs font-medium ${status.badgeClass}`}>
+            {status.label}
+          </span>
+        )}
+      </header>
+
+      <div className="mt-4 text-sm text-slate-600">
+        {isLoading && <ChecksSkeleton />}
+        {error && (
+          <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+            {error instanceof ApiError ? error.message : "Impossibile recuperare lo stato"}
+          </p>
+        )}
+        {!isLoading && !error && (
+          <ul className="space-y-2" aria-live="polite">
+            {checks.length === 0 && <li>Nessun check registrato.</li>}
+            {checks.map(([service, healthy]) => (
+              <li key={service} className="flex items-center justify-between gap-3">
+                <span className="font-medium text-slate-700">{service}</span>
+                <span
+                  className={`inline-flex items-center gap-2 rounded-full border px-2 py-1 text-xs font-semibold ${
+                    healthy
+                      ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+                      : "border-red-200 bg-red-50 text-red-700"
+                  }`}
+                >
+                  <span className={`h-2 w-2 rounded-full ${healthy ? "bg-emerald-500" : "bg-red-500"}`} />
+                  {healthy ? "OK" : "Down"}
+                </span>
+              </li>
             ))}
           </ul>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+    </section>
   );
 }

--- a/apps/web/src/components/JobsChart.tsx
+++ b/apps/web/src/components/JobsChart.tsx
@@ -1,36 +1,109 @@
-﻿"use client";
+"use client";
+
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 
-type Point = { t: string; success: number; failed: number };
+import { ApiError, apiGet } from "../lib/api";
 
-async function fetchSeries(): Promise<Point[]> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/jobs/series?window=1h`, { cache: "no-store" });
-  if (!res.ok) throw new Error("Failed to fetch jobs series");
-  return res.json();
+type JobSeriesPoint = {
+  t: string;
+  success: number;
+  failed: number;
+};
+
+function ChartSkeleton() {
+  return (
+    <div className="flex h-48 items-end gap-2">
+      {Array.from({ length: 12 }).map((_, index) => (
+        <div key={index} className="flex-1 space-y-2">
+          <div className="h-16 animate-pulse rounded bg-slate-200" />
+          <div className="h-10 animate-pulse rounded bg-slate-100" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function formatTimestamp(timestamp: string) {
+  const date = new Date(timestamp);
+  return new Intl.DateTimeFormat("it-IT", {
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
 }
 
 export function JobsChart() {
-  const { data, error, isLoading } = useQuery({
+  const { data, error, isLoading } = useQuery<JobSeriesPoint[], Error>({
     queryKey: ["jobs-series"],
-    queryFn: fetchSeries,
+    queryFn: () => apiGet<JobSeriesPoint[]>("/jobs/series?window=1h"),
     refetchInterval: 6000,
   });
 
-  if (isLoading) return <div className="rounded-lg border p-4">Loading chart...</div>;
-  if (error) return <div className="rounded-lg border p-4 text-red-600">Errore chart</div>;
+  const { maxValue, points } = useMemo(() => {
+    if (!data || data.length === 0) {
+      return { maxValue: 1, points: [] as JobSeriesPoint[] };
+    }
+
+    const maximum = Math.max(
+      1,
+      ...data.map((point) => Math.max(point.success, point.failed))
+    );
+
+    return { maxValue: maximum, points: data };
+  }, [data]);
 
   return (
-    <div className="rounded-lg border p-4">
-      <h2 className="text-lg font-medium mb-2">Andamento ultimi job</h2>
-      <div className="h-40 grid grid-cols-12 gap-1 items-end">
-        {data?.map((p, i) => (
-          <div key={i} className="col-span-1 flex flex-col gap-1">
-            <div className="bg-green-500" style={{ height: `${Math.min(100, p.success)}%`, minHeight: 2 }} />
-            <div className="bg-red-500" style={{ height: `${Math.min(100, p.failed)}%`, minHeight: 2 }} />
-          </div>
-        ))}
+    <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <header className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Andamento ultimi job</h2>
+          <p className="text-sm text-slate-500">Ultima ora, aggiornamento automatico</p>
+        </div>
+      </header>
+
+      <div className="mt-4">
+        {isLoading && <ChartSkeleton />}
+        {error && (
+          <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+            {error instanceof ApiError ? error.message : "Impossibile recuperare la serie dei job"}
+          </p>
+        )}
+        {!isLoading && !error && (
+          <>
+            {points.length === 0 ? (
+              <p className="text-sm text-slate-500">{"Nessun job registrato nell’ultima ora."}</p>
+            ) : (
+              <div role="img" aria-label="Grafico a barre dei job" className="flex h-48 items-end gap-2">
+                {points.map((point) => {
+                  const successHeight = (point.success / maxValue) * 100;
+                  const failedHeight = (point.failed / maxValue) * 100;
+
+                  return (
+                    <div key={point.t} className="flex-1">
+                      <div className="flex h-full flex-col justify-end gap-1">
+                        <div
+                          className="rounded-t bg-emerald-500"
+                          style={{ height: `${successHeight}%`, minHeight: point.success > 0 ? 4 : 0 }}
+                          aria-hidden
+                        />
+                        <div
+                          className="rounded-b bg-rose-500"
+                          style={{ height: `${failedHeight}%`, minHeight: point.failed > 0 ? 4 : 0 }}
+                          aria-hidden
+                        />
+                      </div>
+                      <div className="mt-2 text-center text-xs text-slate-500">
+                        {formatTimestamp(point.t)}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            <p className="mt-3 text-xs text-slate-500">Verde = successi, Rosa = fallimenti. Le colonne sono normalizzate sul valore massimo.</p>
+          </>
+        )}
       </div>
-      <p className="text-xs text-gray-500 mt-2">Green=success, Red=failed (scaled)</p>
-    </div>
+    </section>
   );
 }

--- a/apps/web/src/components/QueuesWidget.tsx
+++ b/apps/web/src/components/QueuesWidget.tsx
@@ -1,42 +1,104 @@
-﻿"use client";
+"use client";
+
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 
-type QueueStats = { active: number; waiting: number; failed: number };
+import { ApiError, apiGet } from "../lib/api";
 
-async function fetchQueues(): Promise<QueueStats> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/queues/summary`, { cache: "no-store" });
-  if (!res.ok) throw new Error("Failed to fetch queues");
-  return res.json();
+type QueueStats = {
+  active: number;
+  waiting: number;
+  failed: number;
+};
+
+const STAT_DEFINITION: Array<{
+  key: keyof QueueStats;
+  label: string;
+  description: string;
+  accentClass: string;
+}> = [
+  {
+    key: "active",
+    label: "Attivi",
+    description: "Job in elaborazione",
+    accentClass: "border-blue-200 bg-blue-50 text-blue-700",
+  },
+  {
+    key: "waiting",
+    label: "In coda",
+    description: "Job in attesa",
+    accentClass: "border-slate-200 bg-slate-50 text-slate-700",
+  },
+  {
+    key: "failed",
+    label: "Falliti",
+    description: "Richiedono attenzione",
+    accentClass: "border-rose-200 bg-rose-50 text-rose-700",
+  },
+];
+
+const numberFormatter = new Intl.NumberFormat("it-IT");
+
+function StatSkeleton() {
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      {STAT_DEFINITION.map(({ key }) => (
+        <div key={key} className="rounded-lg border border-slate-200 p-3">
+          <div className="h-6 w-16 animate-pulse rounded bg-slate-200" />
+          <div className="mt-2 h-4 w-full animate-pulse rounded bg-slate-200" />
+        </div>
+      ))}
+    </div>
+  );
 }
 
 export function QueuesWidget() {
-  const { data, error, isLoading } = useQuery({
+  const { data, error, isLoading } = useQuery<QueueStats, Error>({
     queryKey: ["queues"],
-    queryFn: fetchQueues,
+    queryFn: () => apiGet<QueueStats>("/queues/summary"),
     refetchInterval: 4000,
   });
 
+  const stats = useMemo(() => {
+    if (!data) return null;
+    return STAT_DEFINITION.map((definition) => ({
+      ...definition,
+      value: data[definition.key],
+    }));
+  }, [data]);
+
   return (
-    <div className="rounded-lg border p-4">
-      <h2 className="text-lg font-medium mb-2">Job Queues</h2>
-      {isLoading && <p>Loading...</p>}
-      {error && <p className="text-red-600">Errore queues</p>}
-      {data && (
-        <div className="grid grid-cols-3 gap-4 text-center">
-          <div>
-            <div className="text-2xl font-bold">{data.active}</div>
-            <div className="text-sm text-gray-500">Active</div>
-          </div>
-          <div>
-            <div className="text-2xl font-bold">{data.waiting}</div>
-            <div className="text-sm text-gray-500">Waiting</div>
-          </div>
-          <div>
-            <div className="text-2xl font-bold">{data.failed}</div>
-            <div className="text-sm text-gray-500">Failed</div>
-          </div>
+    <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <header className="flex items-start justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Job Queues</h2>
+          <p className="text-sm text-slate-500">Monitoraggio BullMQ</p>
         </div>
-      )}
-    </div>
+      </header>
+
+      <div className="mt-4 text-sm text-slate-600">
+        {isLoading && <StatSkeleton />}
+        {error && (
+          <p className="rounded-md border border-red-200 bg-red-50 p-3 text-red-700">
+            {error instanceof ApiError ? error.message : "Impossibile recuperare le code"}
+          </p>
+        )}
+        {stats && (
+          <dl className="grid grid-cols-1 gap-4 md:grid-cols-3" aria-live="polite">
+            {stats.map(({ key, label, description, accentClass, value }) => (
+              <div key={key} className="rounded-lg border border-slate-200 p-4">
+                <dt className="text-sm font-medium text-slate-500">{label}</dt>
+                <dd className="mt-2 text-3xl font-semibold text-slate-900">
+                  <span className={`inline-flex rounded-full border px-3 py-1 text-base ${accentClass}`}>
+                    {numberFormatter.format(value)}
+                  </span>
+                </dd>
+                <p className="mt-2 text-xs text-slate-500">{description}</p>
+              </div>
+            ))}
+          </dl>
+        )}
+      </div>
+    </section>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,30 @@
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+type ApiRequestInit = globalThis.RequestInit;
+
+export class ApiError extends Error {
+  readonly status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+export async function apiGet<T>(path: string, init?: ApiRequestInit): Promise<T> {
+  if (!API_BASE_URL) {
+    throw new ApiError("Missing NEXT_PUBLIC_API_BASE_URL environment variable");
+  }
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    cache: "no-store",
+    ...init,
+  });
+
+  if (!response.ok) {
+    throw new ApiError(`Request failed with status ${response.status}`, response.status);
+  }
+
+  return response.json() as Promise<T>;
+}


### PR DESCRIPTION
## Summary
- refresh the /dashboard layout and styling for the operations view
- add reusable API helper and enrich health, queue and job widgets with status-aware UI

## Testing
- pnpm --filter @influencerai/web lint

------
https://chatgpt.com/codex/tasks/task_e_68e02f3c788883208abd9d2ad335688a