### PR TITLE
chore(worker): migrate tests to vitest

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -7,7 +7,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint src/**/*.ts --fix",
-    "test": "tsx --test src/**/*.test.ts"
+    "test": "vitest run",
+    "test:watch": "vitest watch"
   },
   "dependencies": {
     "bullmq": "^5.38.2",
@@ -28,6 +29,7 @@
     "@typescript-eslint/parser": "^8.20.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
-    "eslint": "^9.18.0"
+    "eslint": "^9.18.0",
+    "vitest": "^2.1.9"
   }
 }

--- a/apps/worker/src/processors/contentGeneration.test.ts
+++ b/apps/worker/src/processors/contentGeneration.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
+import { describe, expect, it } from 'vitest';
 import { createContentGenerationProcessor } from './contentGeneration';
 
 const noopLogger = {
@@ -8,109 +7,111 @@ const noopLogger = {
   error: () => {},
 };
 
-test('content generation processor orchestrates caption, script, assets and child job', async () => {
-  const openRouterResponses = [
-    { content: ' caption one ', usage: { total_tokens: 10 } },
-    { content: ' script one ', usage: { total_tokens: 20 } },
-  ];
-  const patchCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
-  const uploadCalls: Array<{ jobIdentifier: string; caption: string; script: string }> = [];
-  let childJobPayload: Record<string, unknown> | undefined;
+describe('content generation processor', () => {
+  it('orchestrates caption, script, assets and child job', async () => {
+    const openRouterResponses = [
+      { content: ' caption one ', usage: { total_tokens: 10 } },
+      { content: ' script one ', usage: { total_tokens: 20 } },
+    ];
+    const patchCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
+    const uploadCalls: Array<{ jobIdentifier: string; caption: string; script: string }> = [];
+    let childJobPayload: Record<string, unknown> | undefined;
 
-  const processor = createContentGenerationProcessor({
-    logger: noopLogger,
-    callOpenRouter: async () => {
-      const next = openRouterResponses.shift();
-      assert.ok(next, 'expected open router calls');
-      return next;
-    },
-    patchJobStatus: async (id, data) => {
-      patchCalls.push({ id, data });
-    },
-    createChildJob: async (input) => {
-      childJobPayload = input as Record<string, unknown>;
-      return { id: 'child-123' } as any;
-    },
-    uploadTextAssets: async (input) => {
-      uploadCalls.push(input);
-      return { captionUrl: 'https://example.com/caption', scriptUrl: 'https://example.com/script' };
-    },
-    prompts: {
-      imageCaptionPrompt: (value) => `CAPTION_PROMPT:${value}`,
-      videoScriptPrompt: (caption, duration) => `SCRIPT_PROMPT:${caption}:${duration}`,
-    },
-  });
-
-  const result = await processor({
-    id: 'queue-1',
-    name: 'content-job',
-    data: {
-      jobId: 'job-1',
-      payload: {
-        personaText: 'persona',
-        context: 'launch',
-        durationSec: 45,
+    const processor = createContentGenerationProcessor({
+      logger: noopLogger,
+      callOpenRouter: async () => {
+        const next = openRouterResponses.shift();
+        if (!next) {
+          throw new Error('expected open router calls');
+        }
+        return next;
       },
-    },
-  } as any);
-
-  assert.equal(result.caption, 'caption one');
-  assert.equal(result.script, 'script one');
-  assert.equal(result.captionUrl, 'https://example.com/caption');
-  assert.equal(result.scriptUrl, 'https://example.com/script');
-  assert.equal(result.childJobId, 'child-123');
-
-  assert.deepEqual(uploadCalls, [
-    { jobIdentifier: 'job-1', caption: ' caption one ', script: ' script one ' },
-  ]);
-
-  assert.ok(childJobPayload);
-  assert.deepEqual(childJobPayload, {
-    parentJobId: 'job-1',
-    caption: ' caption one ',
-    script: ' script one ',
-    persona: 'persona',
-    context: 'launch',
-    durationSec: 45,
-  });
-
-  assert.equal(patchCalls.length, 2);
-  assert.deepEqual(patchCalls[0], { id: 'job-1', data: { status: 'running' } });
-  assert.deepEqual(patchCalls[1], {
-    id: 'job-1',
-    data: {
-      status: 'succeeded',
-      result: {
-        caption: 'caption one',
-        script: 'script one',
-        captionUrl: 'https://example.com/caption',
-        scriptUrl: 'https://example.com/script',
-        childJobId: 'child-123',
+      patchJobStatus: async (id, data) => {
+        patchCalls.push({ id, data });
       },
-      costTok: 30,
-    },
+      createChildJob: async (input) => {
+        childJobPayload = input as Record<string, unknown>;
+        return { id: 'child-123' } as any;
+      },
+      uploadTextAssets: async (input) => {
+        uploadCalls.push(input);
+        return { captionUrl: 'https://example.com/caption', scriptUrl: 'https://example.com/script' };
+      },
+      prompts: {
+        imageCaptionPrompt: (value) => `CAPTION_PROMPT:${value}`,
+        videoScriptPrompt: (caption, duration) => `SCRIPT_PROMPT:${caption}:${duration}`,
+      },
+    });
+
+    const result = await processor({
+      id: 'queue-1',
+      name: 'content-job',
+      data: {
+        jobId: 'job-1',
+        payload: {
+          personaText: 'persona',
+          context: 'launch',
+          durationSec: 45,
+        },
+      },
+    } as any);
+
+    expect(result.caption).toBe('caption one');
+    expect(result.script).toBe('script one');
+    expect(result.captionUrl).toBe('https://example.com/caption');
+    expect(result.scriptUrl).toBe('https://example.com/script');
+    expect(result.childJobId).toBe('child-123');
+
+    expect(uploadCalls).toEqual([
+      { jobIdentifier: 'job-1', caption: ' caption one ', script: ' script one ' },
+    ]);
+
+    expect(childJobPayload).toBeDefined();
+    expect(childJobPayload).toEqual({
+      parentJobId: 'job-1',
+      caption: ' caption one ',
+      script: ' script one ',
+      persona: 'persona',
+      context: 'launch',
+      durationSec: 45,
+    });
+
+    expect(patchCalls).toHaveLength(2);
+    expect(patchCalls[0]).toEqual({ id: 'job-1', data: { status: 'running' } });
+    expect(patchCalls[1]).toEqual({
+      id: 'job-1',
+      data: {
+        status: 'succeeded',
+        result: {
+          caption: 'caption one',
+          script: 'script one',
+          captionUrl: 'https://example.com/caption',
+          scriptUrl: 'https://example.com/script',
+          childJobId: 'child-123',
+        },
+        costTok: 30,
+      },
+    });
   });
-});
 
-test('content generation processor reports failure to API when OpenRouter fails', async () => {
-  const patchCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
+  it('reports failure to API when OpenRouter fails', async () => {
+    const patchCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
 
-  const processor = createContentGenerationProcessor({
-    logger: noopLogger,
-    callOpenRouter: async () => {
-      throw new Error('rate limited');
-    },
-    patchJobStatus: async (id, data) => {
-      patchCalls.push({ id, data });
-    },
-    prompts: {
-      imageCaptionPrompt: (value) => `CAPTION_PROMPT:${value}`,
-      videoScriptPrompt: (caption, duration) => `SCRIPT_PROMPT:${caption}:${duration}`,
-    },
-  });
+    const processor = createContentGenerationProcessor({
+      logger: noopLogger,
+      callOpenRouter: async () => {
+        throw new Error('rate limited');
+      },
+      patchJobStatus: async (id, data) => {
+        patchCalls.push({ id, data });
+      },
+      prompts: {
+        imageCaptionPrompt: (value) => `CAPTION_PROMPT:${value}`,
+        videoScriptPrompt: (caption, duration) => `SCRIPT_PROMPT:${caption}:${duration}`,
+      },
+    });
 
-  await assert.rejects(
-    () =>
+    await expect(
       processor({
         id: 'queue-err',
         name: 'content-job',
@@ -120,11 +121,11 @@ test('content generation processor reports failure to API when OpenRouter fails'
             personaText: 'persona',
           },
         },
-      } as any),
-    /rate limited/
-  );
+      } as any)
+    ).rejects.toThrow(/rate limited/);
 
-  assert.deepEqual(patchCalls[0], { id: 'job-err', data: { status: 'running' } });
-  assert.equal(patchCalls[1]?.id, 'job-err');
-  assert.equal(patchCalls[1]?.data?.status, 'failed');
+    expect(patchCalls[0]).toEqual({ id: 'job-err', data: { status: 'running' } });
+    expect(patchCalls[1]?.id).toBe('job-err');
+    expect(patchCalls[1]?.data?.status).toBe('failed');
+  });
 });

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.2
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0)
 
   packages/core-schemas:
     dependencies:


### PR DESCRIPTION
## Summary
- add vitest test runner configuration to the worker package
- migrate the content generation processor test from node:test to vitest

## Testing
- pnpm --filter @influencerai/worker test

------
https://chatgpt.com/codex/tasks/task_e_68e055c9409c83209375130650c88484