### PR TITLE
Stabilize worker TypeScript config and Vitest mocks

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint src/**/*.ts --fix",
-    "test": "tsx --test src/**/*.test.ts"
+    "test": "vitest run"
   },
   "dependencies": {
     "bullmq": "^5.38.2",
@@ -28,6 +28,7 @@
     "@typescript-eslint/parser": "^8.20.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
-    "eslint": "^9.18.0"
+    "eslint": "^9.18.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/apps/worker/src/index.test.ts
+++ b/apps/worker/src/index.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Worker } from 'bullmq';
+import type Redis from 'ioredis';
+import type { InfluencerAIClient } from '@influencerai/sdk';
+import type { Logger } from 'pino';
+
+type WorkerMockInstance = {
+  name: string;
+  processor: (...args: any[]) => unknown;
+  opts: unknown;
+  handlers: Map<string, (...args: any[]) => unknown>;
+  on: ReturnType<typeof vi.fn>;
+};
+
+const workerMockState = vi.hoisted(() => {
+  const instances: WorkerMockInstance[] = [];
+  const WorkerMockFn = vi.fn<WorkerMockInstance, ConstructorParameters<typeof Worker>>((name, processor, opts) => {
+    const handlers = new Map<string, (...args: any[]) => unknown>();
+    const instance: WorkerMockInstance = {
+      name,
+      processor,
+      opts,
+      handlers,
+      on: vi.fn((event: string, handler: (...args: any[]) => unknown) => {
+        handlers.set(event, handler);
+        return instance;
+      }),
+    };
+    instances.push(instance);
+    return instance;
+  });
+  const WorkerMock = WorkerMockFn as unknown as WorkerConstructor;
+  return { instances, WorkerMock, WorkerMockFn };
+});
+
+type WorkerConstructor = typeof Worker;
+
+const loggerMockState = vi.hoisted(() => {
+  const logger: Pick<Logger, 'info' | 'warn' | 'error'> = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return { logger };
+});
+
+const contentProcessorMockState = vi.hoisted(() => {
+  const processorFn = vi.fn();
+  const factory = vi.fn(() => processorFn as any);
+  return { processorFn, factory };
+});
+
+const promptsMockState = vi.hoisted(() => ({
+  imageCaptionPrompt: vi.fn(),
+  videoScriptPrompt: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({
+  Worker: workerMockState.WorkerMock,
+}));
+
+vi.mock('ioredis', () => ({
+  default: vi.fn(() => ({ disconnect: vi.fn() })),
+}));
+
+vi.mock('@influencerai/sdk', () => {
+  class FakeClient {
+    updateJob = vi.fn();
+    createJob = vi.fn();
+    constructor(public baseUrl: string) {}
+  }
+  return { InfluencerAIClient: FakeClient };
+}, { virtual: true });
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: vi.fn(),
+  PutObjectCommand: vi.fn(),
+  GetObjectCommand: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: vi.fn(),
+}));
+
+vi.mock('./logger', () => loggerMockState);
+
+vi.mock('./processors/contentGeneration', () => ({
+  createContentGenerationProcessor: contentProcessorMockState.factory,
+}));
+
+vi.mock('@influencerai/prompts', () => promptsMockState, { virtual: true });
+
+function getHandler(instance: WorkerMockInstance, event: string) {
+  const handler = instance.handlers.get(event);
+  expect(handler, `Handler for event "${event}" to be registered`).toBeTruthy();
+  return handler!;
+}
+
+describe('worker bootstrap', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    workerMockState.instances.length = 0;
+    contentProcessorMockState.factory.mockClear();
+    contentProcessorMockState.processorFn.mockClear();
+    loggerMockState.logger.info.mockClear();
+    loggerMockState.logger.warn.mockClear();
+    loggerMockState.logger.error.mockClear();
+    process.env.NODE_ENV = 'test';
+    process.env.BULL_PREFIX = 'test-prefix';
+  });
+
+  it('instantiates workers and registers event handlers', async () => {
+    const { createWorkers } = await import('./index');
+
+    const patchJobStatus = vi.fn().mockResolvedValue(undefined);
+    const connection = { kind: 'redis' } as unknown as Redis;
+    const apiClient = { updateJob: vi.fn(), createJob: vi.fn() } as unknown as InfluencerAIClient;
+
+    const result = createWorkers({
+      connection,
+      apiClient,
+      logger: loggerMockState.logger,
+      patchJobStatus,
+      contentProcessorFactory: contentProcessorMockState.factory,
+      prefix: 'queue-prefix',
+    });
+
+    expect(result.contentWorker).toBe(workerMockState.instances[0]);
+    expect(result.loraWorker).toBe(workerMockState.instances[1]);
+    expect(result.patchJobStatus).toBe(patchJobStatus);
+    expect(result.apiClient).toBe(apiClient);
+    expect(result.connection).toBe(connection);
+
+    expect(workerMockState.WorkerMockFn).toHaveBeenCalledTimes(2);
+    expect(workerMockState.WorkerMockFn).toHaveBeenNthCalledWith(1, 'content-generation', contentProcessorMockState.processorFn, {
+      connection,
+      prefix: 'queue-prefix',
+    });
+    expect(workerMockState.WorkerMockFn.mock.calls[1][0]).toBe('lora-training');
+    expect(typeof workerMockState.WorkerMockFn.mock.calls[1][1]).toBe('function');
+    expect(workerMockState.WorkerMockFn.mock.calls[1][2]).toEqual({ connection, prefix: 'queue-prefix' });
+
+    expect(contentProcessorMockState.factory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        logger: loggerMockState.logger,
+        patchJobStatus,
+        callOpenRouter: expect.any(Function),
+        createChildJob: expect.any(Function),
+        uploadTextAssets: expect.any(Function),
+        prompts: promptsMockState,
+      })
+    );
+
+    const contentFailedHandler = getHandler(workerMockState.instances[0], 'failed');
+    const failure = new Error('boom');
+    contentFailedHandler({ data: { jobId: 'job-123' } }, failure);
+    expect(patchJobStatus).toHaveBeenCalledWith('job-123', {
+      status: 'failed',
+      result: { message: failure.message, stack: failure.stack },
+    });
+
+    patchJobStatus.mockClear();
+    contentFailedHandler({ data: {} }, failure);
+    expect(patchJobStatus).not.toHaveBeenCalled();
+
+    const loraFailedHandler = getHandler(workerMockState.instances[1], 'failed');
+    const loraError = new Error('oops');
+    loraFailedHandler({ data: { jobId: 'lora-1' } }, loraError);
+    expect(patchJobStatus).toHaveBeenCalledWith('lora-1', {
+      status: 'failed',
+      result: { message: loraError.message, stack: loraError.stack },
+    });
+  });
+
+  it('swallows errors thrown by patchJobStatus handlers', async () => {
+    const { createWorkers } = await import('./index');
+
+    const patchJobStatus = vi.fn().mockRejectedValue(new Error('network'));
+    createWorkers({
+      logger: loggerMockState.logger,
+      patchJobStatus: patchJobStatus as unknown as (jobId: string, data: any) => Promise<void>,
+      contentProcessorFactory: contentProcessorMockState.factory,
+    });
+
+    const failedHandler = getHandler(workerMockState.instances[0], 'failed');
+    expect(() => failedHandler({ data: { jobId: '123' } }, new Error('fail'))).not.toThrow();
+    await Promise.resolve();
+    expect(patchJobStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,12 +1,13 @@
 import { Worker } from 'bullmq';
+import type { Job } from 'bullmq';
 import Redis from 'ioredis';
-import { logger } from './logger';
+import { logger as defaultLogger } from './logger';
 import { InfluencerAIClient } from '@influencerai/sdk';
 import type { JobResponse } from '@influencerai/sdk';
 import { imageCaptionPrompt, videoScriptPrompt } from '@influencerai/prompts';
 import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { createContentGenerationProcessor } from './processors/contentGeneration';
+import { createContentGenerationProcessor as defaultCreateContentGenerationProcessor } from './processors/contentGeneration';
 
 // Lightweight HTTP helpers (aligned with API app)
 class HTTPError extends Error {
@@ -128,7 +129,9 @@ async function callOpenRouter(messages: { role: 'system' | 'user' | 'assistant';
 }
 
 // Minimal S3 helpers
-function getS3Client(): { client: S3Client; bucket: string } | null {
+type LoggerLike = Pick<typeof defaultLogger, 'info' | 'warn' | 'error'>;
+
+function getS3Client(logger: LoggerLike = defaultLogger): { client: S3Client; bucket: string } | null {
   const endpoint = process.env.S3_ENDPOINT || 'http://localhost:9000';
   const region = process.env.AWS_REGION || 'us-east-1';
   const accessKeyId = process.env.S3_KEY || 'minio';
@@ -143,7 +146,7 @@ function getS3Client(): { client: S3Client; bucket: string } | null {
     });
     return { client, bucket };
   } catch (e) {
-    logger.warn({ e }, 'Unable to initialize S3 client');
+    logger.warn({ err: e }, 'Unable to initialize S3 client');
     return null;
   }
 }
@@ -159,110 +162,158 @@ async function getSignedGetUrlS3(client: S3Client, bucket: string, key: string, 
   return getSignedUrl(client, cmd, { expiresIn: expiresInSeconds });
 }
 
-const connection = new Redis({
-  host: process.env.REDIS_HOST || 'localhost',
-  port: parseInt(process.env.REDIS_PORT || '6379'),
-  maxRetriesPerRequest: null,
-});
+type PatchJobStatusPayload = {
+  status?: 'running' | 'succeeded' | 'failed' | 'completed';
+  result?: unknown;
+  costTok?: number;
+};
 
-const apiBaseUrl = process.env.API_BASE_URL || process.env.WORKER_API_URL || 'http://localhost:3001';
-const api = new InfluencerAIClient(apiBaseUrl);
+type WorkerConstructor = typeof Worker;
 
-async function patchJobStatus(jobId: string, data: { status?: 'running' | 'succeeded' | 'failed' | 'completed'; result?: unknown; costTok?: number }) {
-  const maxAttempts = 2;
-  let lastErr: unknown = undefined;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      await api.updateJob(jobId, data);
-      return;
-    } catch (err) {
-      lastErr = err;
-      if (attempt < maxAttempts) {
-        await new Promise((r) => setTimeout(r, 200 * attempt));
+export type CreateWorkersOptions = {
+  WorkerClass?: WorkerConstructor;
+  connection?: Redis;
+  apiClient?: InfluencerAIClient;
+  logger?: LoggerLike;
+  patchJobStatus?: (jobId: string, data: PatchJobStatusPayload) => Promise<void>;
+  contentProcessorFactory?: typeof defaultCreateContentGenerationProcessor;
+  prefix?: string;
+};
+
+export type CreateWorkersResult = {
+  contentWorker: Worker;
+  loraWorker: Worker;
+  patchJobStatus: (jobId: string, data: PatchJobStatusPayload) => Promise<void>;
+  connection: Redis;
+  apiClient: InfluencerAIClient;
+};
+
+export function createWorkers(options: CreateWorkersOptions = {}): CreateWorkersResult {
+  const WorkerImpl = options.WorkerClass ?? Worker;
+  const logger = options.logger ?? defaultLogger;
+  const connection =
+    options.connection ??
+    new Redis({
+      host: process.env.REDIS_HOST || 'localhost',
+      port: parseInt(process.env.REDIS_PORT || '6379'),
+      maxRetriesPerRequest: null,
+    });
+
+  const apiBaseUrl = process.env.API_BASE_URL || process.env.WORKER_API_URL || 'http://localhost:3001';
+  const apiClient = options.apiClient ?? new InfluencerAIClient(apiBaseUrl);
+
+  const patchJobStatusImpl =
+    options.patchJobStatus ??
+    (async (jobId: string, data: PatchJobStatusPayload) => {
+      const maxAttempts = 2;
+      let lastErr: unknown = undefined;
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          await apiClient.updateJob(jobId, data);
+          return;
+        } catch (err) {
+          lastErr = err;
+          if (attempt < maxAttempts) {
+            await new Promise((r) => setTimeout(r, 200 * attempt));
+          }
+        }
       }
+      logger.warn({ err: lastErr, jobId, data }, 'Failed to PATCH job status after retries');
+    });
+
+  const prefix = options.prefix ?? process.env.BULL_PREFIX;
+  const contentProcessorFactory = options.contentProcessorFactory ?? defaultCreateContentGenerationProcessor;
+
+  const contentProcessor = contentProcessorFactory({
+      logger,
+      callOpenRouter,
+      patchJobStatus: patchJobStatusImpl,
+      createChildJob: async ({ parentJobId, caption, script, persona, context, durationSec }) =>
+        apiClient.createJob({
+          type: 'video-generation',
+          payload: {
+            parentJobId,
+            caption,
+            script,
+            persona,
+            context,
+            durationSec,
+          },
+          priority: 5,
+        }) as Promise<JobResponse>,
+      uploadTextAssets: async ({ jobIdentifier, caption, script }) => {
+        const s3 = getS3Client(logger);
+        if (!s3) return {};
+        const { client, bucket } = s3;
+        const baseKey = `content-generation/${jobIdentifier}/`;
+        const captionKey = `${baseKey}caption.txt`;
+        const scriptKey = `${baseKey}script.txt`;
+        await putTextObjectS3(client, bucket, captionKey, caption || '');
+        await putTextObjectS3(client, bucket, scriptKey, script || '');
+        const captionUrl = await getSignedGetUrlS3(client, bucket, captionKey, 24 * 3600);
+        const scriptUrl = await getSignedGetUrlS3(client, bucket, scriptKey, 24 * 3600);
+        return { captionUrl, scriptUrl };
+      },
+      prompts: { imageCaptionPrompt, videoScriptPrompt },
+    });
+
+  const contentWorker = new WorkerImpl(
+    'content-generation',
+    contentProcessor as ConstructorParameters<WorkerConstructor>[1],
+    { connection, prefix }
+  );
+
+  const loraWorker = new WorkerImpl(
+    'lora-training',
+    (async (job) => {
+      logger.info({ id: job.id, data: job.data }, 'Processing LoRA training job');
+      const jobId = (job.data as any)?.jobId as string | undefined;
+      if (jobId) await patchJobStatusImpl(jobId, { status: 'running' });
+
+      // TODO: Implement LoRA training logic
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      const result = { success: true, result: 'Training completed' };
+      if (jobId) await patchJobStatusImpl(jobId, { status: 'succeeded', result });
+      return result;
+    }) as ConstructorParameters<WorkerConstructor>[1],
+    { connection, prefix }
+  );
+
+  contentWorker.on('completed', (job: Job) => {
+    logger.info({ id: job.id }, 'Job completed successfully');
+  });
+
+  contentWorker.on('failed', (job: Job | undefined, err: Error) => {
+    logger.error({ id: job?.id, err }, 'Job failed');
+    const jobId = (job?.data as any)?.jobId as string | undefined;
+    if (jobId) {
+      patchJobStatusImpl(jobId, { status: 'failed', result: { message: (err as any)?.message, stack: (err as any)?.stack } }).catch(() => {});
     }
-  }
-  logger.warn({ err: lastErr, jobId, data }, 'Failed to PATCH job status after retries');
+  });
+
+  loraWorker.on('completed', (job: Job) => {
+    logger.info({ id: job.id }, 'LoRA training job completed successfully');
+  });
+
+  loraWorker.on('failed', (job: Job | undefined, err: Error) => {
+    logger.error({ id: job?.id, err }, 'LoRA training job failed');
+    const jobId = (job?.data as any)?.jobId as string | undefined;
+    if (jobId) {
+      patchJobStatusImpl(jobId, { status: 'failed', result: { message: (err as any)?.message, stack: (err as any)?.stack } }).catch(() => {});
+    }
+  });
+
+  logger.info('Workers started and listening for jobs...');
+
+  return { contentWorker, loraWorker, patchJobStatus: patchJobStatusImpl, connection, apiClient };
 }
 
-// Content generation worker
-const contentWorker = new Worker(
-  'content-generation',
-  createContentGenerationProcessor({
-    logger,
-    callOpenRouter,
-    patchJobStatus,
-    createChildJob: async ({ parentJobId, caption, script, persona, context, durationSec }) =>
-      api.createJob({
-        type: 'video-generation',
-        payload: {
-          parentJobId,
-          caption,
-          script,
-          persona,
-          context,
-          durationSec,
-        },
-        priority: 5,
-      }) as Promise<JobResponse>,
-    uploadTextAssets: async ({ jobIdentifier, caption, script }) => {
-      const s3 = getS3Client();
-      if (!s3) return {};
-      const { client, bucket } = s3;
-      const baseKey = `content-generation/${jobIdentifier}/`;
-      const captionKey = `${baseKey}caption.txt`;
-      const scriptKey = `${baseKey}script.txt`;
-      await putTextObjectS3(client, bucket, captionKey, caption || '');
-      await putTextObjectS3(client, bucket, scriptKey, script || '');
-      const captionUrl = await getSignedGetUrlS3(client, bucket, captionKey, 24 * 3600);
-      const scriptUrl = await getSignedGetUrlS3(client, bucket, scriptKey, 24 * 3600);
-      return { captionUrl, scriptUrl };
-    },
-    prompts: { imageCaptionPrompt, videoScriptPrompt },
-  }),
-  { connection, prefix: process.env.BULL_PREFIX }
-);
+let startedWorkers: CreateWorkersResult | null = null;
 
-// LoRA training worker
-const loraWorker = new Worker(
-  'lora-training',
-  async (job) => {
-    logger.info({ id: job.id, data: job.data }, 'Processing LoRA training job');
-    const jobId = (job.data as any)?.jobId as string | undefined;
-    if (jobId) await patchJobStatus(jobId, { status: 'running' });
+if (process.env.NODE_ENV !== 'test') {
+  startedWorkers = createWorkers();
+}
 
-    // TODO: Implement LoRA training logic
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-
-    const result = { success: true, result: 'Training completed' };
-    if (jobId) await patchJobStatus(jobId, { status: 'succeeded', result });
-    return result;
-  },
-  { connection, prefix: process.env.BULL_PREFIX }
-);
-
-contentWorker.on('completed', (job) => {
-  logger.info({ id: job.id }, 'Job completed successfully');
-});
-
-contentWorker.on('failed', (job, err) => {
-  logger.error({ id: job?.id, err }, 'Job failed');
-  const jobId = (job?.data as any)?.jobId as string | undefined;
-  if (jobId) {
-    patchJobStatus(jobId, { status: 'failed', result: { message: (err as any)?.message, stack: (err as any)?.stack } }).catch(() => {});
-  }
-});
-
-loraWorker.on('completed', (job) => {
-  logger.info({ id: job.id }, 'LoRA training job completed successfully');
-});
-
-loraWorker.on('failed', (job, err) => {
-  logger.error({ id: job?.id, err }, 'LoRA training job failed');
-  const jobId = (job?.data as any)?.jobId as string | undefined;
-  if (jobId) {
-    patchJobStatus(jobId, { status: 'failed', result: { message: (err as any)?.message, stack: (err as any)?.stack } }).catch(() => {});
-  }
-});
-
-logger.info('Workers started and listening for jobs...');
+export const contentWorker = startedWorkers?.contentWorker ?? null;
+export const loraWorker = startedWorkers?.loraWorker ?? null;

--- a/apps/worker/src/processors/contentGeneration.test.ts
+++ b/apps/worker/src/processors/contentGeneration.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
+import { describe, expect, it } from 'vitest';
 import { createContentGenerationProcessor } from './contentGeneration';
 
 const noopLogger = {
@@ -8,109 +7,109 @@ const noopLogger = {
   error: () => {},
 };
 
-test('content generation processor orchestrates caption, script, assets and child job', async () => {
-  const openRouterResponses = [
-    { content: ' caption one ', usage: { total_tokens: 10 } },
-    { content: ' script one ', usage: { total_tokens: 20 } },
-  ];
-  const patchCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
-  const uploadCalls: Array<{ jobIdentifier: string; caption: string; script: string }> = [];
-  let childJobPayload: Record<string, unknown> | undefined;
+describe('content generation processor', () => {
+  it('orchestrates caption, script, assets and child job', async () => {
+    const openRouterResponses = [
+      { content: ' caption one ', usage: { total_tokens: 10 } },
+      { content: ' script one ', usage: { total_tokens: 20 } },
+    ];
+    const patchCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
+    const uploadCalls: Array<{ jobIdentifier: string; caption: string; script: string }> = [];
+    let childJobPayload: Record<string, unknown> | undefined;
 
-  const processor = createContentGenerationProcessor({
-    logger: noopLogger,
-    callOpenRouter: async () => {
-      const next = openRouterResponses.shift();
-      assert.ok(next, 'expected open router calls');
-      return next;
-    },
-    patchJobStatus: async (id, data) => {
-      patchCalls.push({ id, data });
-    },
-    createChildJob: async (input) => {
-      childJobPayload = input as Record<string, unknown>;
-      return { id: 'child-123' } as any;
-    },
-    uploadTextAssets: async (input) => {
-      uploadCalls.push(input);
-      return { captionUrl: 'https://example.com/caption', scriptUrl: 'https://example.com/script' };
-    },
-    prompts: {
-      imageCaptionPrompt: (value) => `CAPTION_PROMPT:${value}`,
-      videoScriptPrompt: (caption, duration) => `SCRIPT_PROMPT:${caption}:${duration}`,
-    },
-  });
-
-  const result = await processor({
-    id: 'queue-1',
-    name: 'content-job',
-    data: {
-      jobId: 'job-1',
-      payload: {
-        personaText: 'persona',
-        context: 'launch',
-        durationSec: 45,
+    const processor = createContentGenerationProcessor({
+      logger: noopLogger,
+      callOpenRouter: async () => {
+        const next = openRouterResponses.shift();
+        expect(next).toBeDefined();
+        return next!;
       },
-    },
-  } as any);
-
-  assert.equal(result.caption, 'caption one');
-  assert.equal(result.script, 'script one');
-  assert.equal(result.captionUrl, 'https://example.com/caption');
-  assert.equal(result.scriptUrl, 'https://example.com/script');
-  assert.equal(result.childJobId, 'child-123');
-
-  assert.deepEqual(uploadCalls, [
-    { jobIdentifier: 'job-1', caption: ' caption one ', script: ' script one ' },
-  ]);
-
-  assert.ok(childJobPayload);
-  assert.deepEqual(childJobPayload, {
-    parentJobId: 'job-1',
-    caption: ' caption one ',
-    script: ' script one ',
-    persona: 'persona',
-    context: 'launch',
-    durationSec: 45,
-  });
-
-  assert.equal(patchCalls.length, 2);
-  assert.deepEqual(patchCalls[0], { id: 'job-1', data: { status: 'running' } });
-  assert.deepEqual(patchCalls[1], {
-    id: 'job-1',
-    data: {
-      status: 'succeeded',
-      result: {
-        caption: 'caption one',
-        script: 'script one',
-        captionUrl: 'https://example.com/caption',
-        scriptUrl: 'https://example.com/script',
-        childJobId: 'child-123',
+      patchJobStatus: async (id, data) => {
+        patchCalls.push({ id, data });
       },
-      costTok: 30,
-    },
+      createChildJob: async (input) => {
+        childJobPayload = input as Record<string, unknown>;
+        return { id: 'child-123' } as any;
+      },
+      uploadTextAssets: async (input) => {
+        uploadCalls.push(input);
+        return { captionUrl: 'https://example.com/caption', scriptUrl: 'https://example.com/script' };
+      },
+      prompts: {
+        imageCaptionPrompt: (value) => `CAPTION_PROMPT:${value}`,
+        videoScriptPrompt: (caption, duration) => `SCRIPT_PROMPT:${caption}:${duration}`,
+      },
+    });
+
+    const result = await processor({
+      id: 'queue-1',
+      name: 'content-job',
+      data: {
+        jobId: 'job-1',
+        payload: {
+          personaText: 'persona',
+          context: 'launch',
+          durationSec: 45,
+        },
+      },
+    } as any);
+
+    expect(result.caption).toBe('caption one');
+    expect(result.script).toBe('script one');
+    expect(result.captionUrl).toBe('https://example.com/caption');
+    expect(result.scriptUrl).toBe('https://example.com/script');
+    expect(result.childJobId).toBe('child-123');
+
+    expect(uploadCalls).toEqual([
+      { jobIdentifier: 'job-1', caption: ' caption one ', script: ' script one ' },
+    ]);
+
+    expect(childJobPayload).toBeDefined();
+    expect(childJobPayload).toEqual({
+      parentJobId: 'job-1',
+      caption: ' caption one ',
+      script: ' script one ',
+      persona: 'persona',
+      context: 'launch',
+      durationSec: 45,
+    });
+
+    expect(patchCalls).toHaveLength(2);
+    expect(patchCalls[0]).toEqual({ id: 'job-1', data: { status: 'running' } });
+    expect(patchCalls[1]).toEqual({
+      id: 'job-1',
+      data: {
+        status: 'succeeded',
+        result: {
+          caption: 'caption one',
+          script: 'script one',
+          captionUrl: 'https://example.com/caption',
+          scriptUrl: 'https://example.com/script',
+          childJobId: 'child-123',
+        },
+        costTok: 30,
+      },
+    });
   });
-});
 
-test('content generation processor reports failure to API when OpenRouter fails', async () => {
-  const patchCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
+  it('reports failure to API when OpenRouter fails', async () => {
+    const patchCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
 
-  const processor = createContentGenerationProcessor({
-    logger: noopLogger,
-    callOpenRouter: async () => {
-      throw new Error('rate limited');
-    },
-    patchJobStatus: async (id, data) => {
-      patchCalls.push({ id, data });
-    },
-    prompts: {
-      imageCaptionPrompt: (value) => `CAPTION_PROMPT:${value}`,
-      videoScriptPrompt: (caption, duration) => `SCRIPT_PROMPT:${caption}:${duration}`,
-    },
-  });
+    const processor = createContentGenerationProcessor({
+      logger: noopLogger,
+      callOpenRouter: async () => {
+        throw new Error('rate limited');
+      },
+      patchJobStatus: async (id, data) => {
+        patchCalls.push({ id, data });
+      },
+      prompts: {
+        imageCaptionPrompt: (value) => `CAPTION_PROMPT:${value}`,
+        videoScriptPrompt: (caption, duration) => `SCRIPT_PROMPT:${caption}:${duration}`,
+      },
+    });
 
-  await assert.rejects(
-    () =>
+    await expect(
       processor({
         id: 'queue-err',
         name: 'content-job',
@@ -120,11 +119,11 @@ test('content generation processor reports failure to API when OpenRouter fails'
             personaText: 'persona',
           },
         },
-      } as any),
-    /rate limited/
-  );
+      } as any)
+    ).rejects.toThrow(/rate limited/);
 
-  assert.deepEqual(patchCalls[0], { id: 'job-err', data: { status: 'running' } });
-  assert.equal(patchCalls[1]?.id, 'job-err');
-  assert.equal(patchCalls[1]?.data?.status, 'failed');
+    expect(patchCalls[0]).toEqual({ id: 'job-err', data: { status: 'running' } });
+    expect(patchCalls[1]?.id).toBe('job-err');
+    expect(patchCalls[1]?.data?.status).toBe('failed');
+  });
 });

--- a/apps/worker/src/types/external.d.ts
+++ b/apps/worker/src/types/external.d.ts
@@ -1,0 +1,17 @@
+declare module '@influencerai/sdk' {
+  export type JobResponse = {
+    id: string;
+    [key: string]: unknown;
+  };
+
+  export class InfluencerAIClient {
+    constructor(baseUrl?: string);
+    updateJob(id: string, update: { status?: string; result?: unknown; costTok?: number }): Promise<void>;
+    createJob(spec: unknown): Promise<JobResponse>;
+  }
+}
+
+declare module '@influencerai/prompts' {
+  export function imageCaptionPrompt(input: string): string;
+  export function videoScriptPrompt(caption: string, durationSec: number): string;
+}

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -10,8 +10,10 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "baseUrl": "./",
+    "types": ["node", "vitest"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts"]
 }

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@influencerai/sdk': path.resolve(__dirname, '../../packages/sdk/src/index.ts'),
+      '@influencerai/prompts': path.resolve(__dirname, '../../packages/prompts/src/index.ts'),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.2
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0)
 
   packages/core-schemas:
     dependencies:
@@ -2439,6 +2442,9 @@ packages:
       '@vitest/browser':
         optional: true
 
+  '@vitest/expect@1.6.1':
+    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -2473,11 +2479,17 @@ packages:
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
+  '@vitest/runner@1.6.1':
+    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
   '@vitest/runner@2.1.9':
     resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@1.6.1':
+    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
 
   '@vitest/snapshot@2.1.9':
     resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
@@ -2485,11 +2497,17 @@ packages:
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
+  '@vitest/spy@1.6.1':
+    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
+
   '@vitest/spy@2.1.9':
     resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@1.6.1':
+    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
@@ -2694,6 +2712,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -2864,6 +2885,10 @@ packages:
   caniuse-lite@1.0.30001745:
     resolution: {integrity: sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==}
 
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -2882,6 +2907,9 @@ packages:
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -2985,6 +3013,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
@@ -3105,6 +3136,10 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
+
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -3450,6 +3485,10 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
@@ -3662,6 +3701,9 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -3677,6 +3719,10 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -3787,6 +3833,10 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -3959,6 +4009,10 @@ packages:
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -4360,6 +4414,10 @@ packages:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
 
+  local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -4411,6 +4469,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -4494,6 +4555,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -4515,6 +4580,9 @@ packages:
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
   mnemonist@0.39.6:
     resolution: {integrity: sha512-A/0v5Z59y63US00cRSLiloEIw3t5G+MiKz4BhX21FI+YBJXBOGW0ohFxTxO08dsOYlzxo87T7vGfZKYp2bcAWA==}
@@ -4635,6 +4703,10 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   nwsapi@2.2.22:
     resolution: {integrity: sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==}
 
@@ -4692,6 +4764,10 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -4715,6 +4791,10 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
 
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
@@ -4773,6 +4853,10 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -4795,6 +4879,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
@@ -4849,6 +4936,9 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
@@ -5347,6 +5437,10 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
@@ -5354,6 +5448,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@2.1.1:
+    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
@@ -5467,6 +5564,10 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -5477,6 +5578,10 @@ packages:
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@3.0.2:
@@ -5633,6 +5738,10 @@ packages:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
 
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
@@ -5666,6 +5775,9 @@ packages:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.1:
+    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
@@ -5736,6 +5848,11 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
+  vite-node@1.6.1:
+    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -5775,6 +5892,31 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+
+  vitest@1.6.1:
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@2.1.9:
@@ -5985,6 +6127,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.1:
+    resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
+    engines: {node: '>=12.20'}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -8511,6 +8657,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@1.6.1':
+    dependencies:
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      chai: 4.5.0
+
   '@vitest/expect@2.1.9':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -8550,6 +8702,12 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/runner@1.6.1':
+    dependencies:
+      '@vitest/utils': 1.6.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
+
   '@vitest/runner@2.1.9':
     dependencies:
       '@vitest/utils': 2.1.9
@@ -8560,6 +8718,12 @@ snapshots:
       '@vitest/utils': 3.2.4
       pathe: 2.0.3
       strip-literal: 3.1.0
+
+  '@vitest/snapshot@1.6.1':
+    dependencies:
+      magic-string: 0.30.19
+      pathe: 1.1.2
+      pretty-format: 29.7.0
 
   '@vitest/snapshot@2.1.9':
     dependencies:
@@ -8573,6 +8737,10 @@ snapshots:
       magic-string: 0.30.19
       pathe: 2.0.3
 
+  '@vitest/spy@1.6.1':
+    dependencies:
+      tinyspy: 2.2.1
+
   '@vitest/spy@2.1.9':
     dependencies:
       tinyspy: 3.0.2
@@ -8580,6 +8748,13 @@ snapshots:
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
+
+  '@vitest/utils@1.6.1':
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -8841,6 +9016,8 @@ snapshots:
 
   asap@2.0.6: {}
 
+  assertion-error@1.1.0: {}
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
@@ -9057,6 +9234,16 @@ snapshots:
 
   caniuse-lite@1.0.30001745: {}
 
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -9075,6 +9262,10 @@ snapshots:
   char-regex@1.0.2: {}
 
   chardet@0.7.0: {}
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
 
   check-error@2.1.1: {}
 
@@ -9165,6 +9356,8 @@ snapshots:
   component-emitter@1.3.1: {}
 
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
 
   confbox@0.2.2: {}
 
@@ -9271,6 +9464,10 @@ snapshots:
   decimal.js@10.6.0: {}
 
   dedent@1.7.0: {}
+
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
 
   deep-eql@5.0.2: {}
 
@@ -9773,6 +9970,18 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+
   exit@0.1.2: {}
 
   expect-type@1.2.2: {}
@@ -10046,6 +10255,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-func-name@2.0.2: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -10067,6 +10278,8 @@ snapshots:
       es-object-atoms: 1.1.1
 
   get-stream@6.0.1: {}
+
+  get-stream@8.0.1: {}
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -10192,6 +10405,8 @@ snapshots:
       - supports-color
 
   human-signals@2.1.0: {}
+
+  human-signals@5.0.0: {}
 
   iconv-lite@0.4.24:
     dependencies:
@@ -10389,6 +10604,8 @@ snapshots:
       call-bound: 1.0.4
 
   is-stream@2.0.1: {}
+
+  is-stream@3.0.0: {}
 
   is-string@1.1.1:
     dependencies:
@@ -11003,6 +11220,11 @@ snapshots:
 
   loader-runner@4.3.0: {}
 
+  local-pkg@0.5.1:
+    dependencies:
+      mlly: 1.8.0
+      pkg-types: 1.3.1
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -11043,6 +11265,10 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
 
   loupe@3.2.1: {}
 
@@ -11109,6 +11335,8 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  mimic-fn@4.0.0: {}
+
   min-indent@1.0.1: {}
 
   minimatch@3.1.2:
@@ -11126,6 +11354,13 @@ snapshots:
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.2
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.1
 
   mnemonist@0.39.6:
     dependencies:
@@ -11236,6 +11471,10 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
+
   nwsapi@2.2.22: {}
 
   nypm@0.6.2:
@@ -11302,6 +11541,10 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -11338,6 +11581,10 @@ snapshots:
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
+  p-limit@5.0.0:
+    dependencies:
+      yocto-queue: 1.2.1
 
   p-locate@4.1.0:
     dependencies:
@@ -11392,6 +11639,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-key@4.0.0: {}
+
   path-parse@1.0.7: {}
 
   path-scurry@1.11.1:
@@ -11408,6 +11657,8 @@ snapshots:
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
+
+  pathval@1.1.1: {}
 
   pathval@2.0.1: {}
 
@@ -11486,6 +11737,12 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
 
   pkg-types@2.3.0:
     dependencies:
@@ -12049,11 +12306,17 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
+  strip-final-newline@3.0.0: {}
+
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@2.1.1:
+    dependencies:
+      js-tokens: 9.0.1
 
   strip-literal@3.1.0:
     dependencies:
@@ -12166,11 +12429,15 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinypool@0.8.4: {}
+
   tinypool@1.1.1: {}
 
   tinyrainbow@1.2.0: {}
 
   tinyrainbow@2.0.0: {}
+
+  tinyspy@2.2.1: {}
 
   tinyspy@3.0.2: {}
 
@@ -12315,6 +12582,8 @@ snapshots:
 
   type-detect@4.0.8: {}
 
+  type-detect@4.1.0: {}
+
   type-fest@0.21.3: {}
 
   type-fest@4.41.0: {}
@@ -12355,6 +12624,8 @@ snapshots:
   typescript@5.7.2: {}
 
   typescript@5.9.2: {}
+
+  ufo@1.6.1: {}
 
   uglify-js@3.19.3:
     optional: true
@@ -12435,6 +12706,24 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
+  vite-node@1.6.1(@types/node@22.18.7)(lightningcss@1.30.1)(terser@5.44.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.20(@types/node@22.18.7)(lightningcss@1.30.1)(terser@5.44.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@2.1.9(@types/node@22.18.7)(lightningcss@1.30.1)(terser@5.44.0):
     dependencies:
       cac: 6.7.14
@@ -12481,6 +12770,41 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.30.1
       terser: 5.44.0
+
+  vitest@1.6.1(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.4
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.19
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.9.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.20(@types/node@22.18.7)(lightningcss@1.30.1)(terser@5.44.0)
+      vite-node: 1.6.1(@types/node@22.18.7)(lightningcss@1.30.1)(terser@5.44.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.18.7
+      jsdom: 24.1.3
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0):
     dependencies:
@@ -12736,5 +13060,7 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.1: {}
 
   zod@3.25.76: {}


### PR DESCRIPTION
## Summary
- update the worker bootstrap to accept a logger-like interface, re-use it in S3 helpers, and tighten worker typings
- refactor the Vitest worker bootstrap tests to use explicit mocks and logger typing while avoiding class mock accessors
- adjust the worker tsconfig and add ambient module stubs so tsc no longer pulls in workspace packages during the build

## Testing
- pnpm --filter @influencerai/worker test
- pnpm --filter @influencerai/worker build

------
https://chatgpt.com/codex/tasks/task_e_68e0565146008320adc08f3f092494b1