### PR TITLE
Restrict install-and-build workflow to PRs

### DIFF
--- a/.github/workflows/install-and-build.yml
+++ b/.github/workflows/install-and-build.yml
@@ -1,8 +1,6 @@
 name: Install & Build (workspace sanity)
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # InfluencerAI
 
+[![CI](https://github.com/DegrassiAaron/influencerai-monorepo/actions/workflows/ci.yml/badge.svg)](https://github.com/DegrassiAaron/influencerai-monorepo/actions/workflows/ci.yml)
+
 [![Sync Backlog Issues](https://github.com/DegrassiAaron/influencerai-monorepo/actions/workflows/sync-backlog-issues.yml/badge.svg)](https://github.com/DegrassiAaron/influencerai-monorepo/actions/workflows/sync-backlog-issues.yml)
 [![Verify Backlog Issues](https://github.com/DegrassiAaron/influencerai-monorepo/actions/workflows/verify-backlog-issues.yml/badge.svg)](https://github.com/DegrassiAaron/influencerai-monorepo/actions/workflows/verify-backlog-issues.yml)
 


### PR DESCRIPTION
## Summary
- update the install-and-build GitHub Actions workflow to run only for pull requests
- add a README badge pointing to the primary CI workflow since install-and-build no longer runs on push

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15de99a3c832094269209f73f9af5