### PR TITLE
chore: switch pre-pr gate workflow to pnpm

### DIFF
--- a/workflows/pre-pr-gate.yml
+++ b/workflows/pre-pr-gate.yml
@@ -33,13 +33,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: 'pnpm'
+      - name: Enable pnpm via Corepack
+        run: corepack enable && corepack prepare pnpm@10.17.1 --activate
       - name: Install & Test (TS)
         run: |
-          if [ -f package-lock.json ] || [ -f package.json ]; then
-            npm ci
-            npm run build --if-present
-            npm test
+          if [ -f pnpm-lock.yaml ] || [ -f package.json ]; then
+            pnpm -w install --frozen-lockfile
+            pnpm -w build
+            pnpm -w test
           fi
 
       # .NET / C#


### PR DESCRIPTION
## Summary
- enable pnpm via corepack and configure the Node setup step to cache pnpm
- run pnpm workspace install, build, and test commands in the TypeScript job

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e7e122be4c8320bce3e709a7869d1b