### PR TITLE
refactor: centralize e2e db reset helper

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -100,6 +100,7 @@ Note:
 
 - Esecuzione test
   - Avvia i test E2E: `pnpm --filter @influencerai/api test:e2e`
+  - Forza un reset del database di test prima dell'esecuzione con `SKIP_DB_RESET=0 pnpm --filter @influencerai/api test:e2e`
   - Le suite interessate sono:
     - `apps/api/test/jobs.roundtrip.redis.e2e-spec.ts` (worker inline di test)
     - `apps/api/test/jobs.roundtrip.realworker.e2e-spec.ts` (worker reale `apps/worker`)
@@ -195,6 +196,7 @@ Note:
 
 - Esecuzione test
   - Avvia i test E2E: `pnpm --filter @influencerai/api test:e2e`
+  - Per forzare un reset completo del database prima della run imposta `SKIP_DB_RESET=0`, ad esempio: `SKIP_DB_RESET=0 pnpm --filter @influencerai/api test:e2e`
   - Le suite interessate sono:
     - `apps/api/test/jobs.roundtrip.redis.e2e-spec.ts` (worker inline di test)
     - `apps/api/test/jobs.roundtrip.realworker.e2e-spec.ts` (worker reale `apps/worker`)

--- a/apps/api/jest.e2e.config.js
+++ b/apps/api/jest.e2e.config.js
@@ -1,12 +1,16 @@
+require('ts-node/register/transpile-only');
+
 module.exports = {
   moduleFileExtensions: ['js', 'json', 'ts'],
   rootDir: '.',
   testRegex: 'test/.*\\.e2e-spec\\.ts$',
   transform: {
-    '^.+\\.(t|j)s$': require.resolve('ts-jest'),
+    '^.+\\.ts$': [require.resolve('ts-jest'), { diagnostics: false }],
   },
   collectCoverageFrom: ['test/**/*.(t|j)s'],
   coverageDirectory: './coverage-e2e',
   testEnvironment: 'node',
   setupFilesAfterEnv: ['<rootDir>/test/setup-e2e.ts'],
+  globalSetup: '<rootDir>/test/global-setup-e2e.js',
+  globalTeardown: '<rootDir>/test/global-teardown-e2e.js',
 };

--- a/apps/api/test/global-setup-e2e.js
+++ b/apps/api/test/global-setup-e2e.js
@@ -1,0 +1,3 @@
+require('ts-node/register/transpile-only');
+
+module.exports = require('./global-setup-e2e.ts').default;

--- a/apps/api/test/global-setup-e2e.ts
+++ b/apps/api/test/global-setup-e2e.ts
@@ -1,0 +1,15 @@
+import { hasDbResetCompleted, loadE2eEnv, markDbResetCompleted, resetTestDb, shouldSkipDbReset } from './utils/reset-db';
+
+export default async function globalSetup() {
+  loadE2eEnv();
+
+  if (hasDbResetCompleted()) {
+    return;
+  }
+
+  const didReset = resetTestDb('globalSetup');
+
+  if (didReset || shouldSkipDbReset()) {
+    markDbResetCompleted();
+  }
+}

--- a/apps/api/test/global-teardown-e2e.js
+++ b/apps/api/test/global-teardown-e2e.js
@@ -1,0 +1,3 @@
+require('ts-node/register/transpile-only');
+
+module.exports = require('./global-teardown-e2e.ts').default;

--- a/apps/api/test/global-teardown-e2e.ts
+++ b/apps/api/test/global-teardown-e2e.ts
@@ -1,0 +1,13 @@
+import { clearDbResetFlag, loadE2eEnv, resetTestDb, shouldSkipDbReset } from './utils/reset-db';
+
+export default async function globalTeardown() {
+  loadE2eEnv();
+
+  try {
+    if (!shouldSkipDbReset()) {
+      resetTestDb('globalTeardown');
+    }
+  } finally {
+    clearDbResetFlag();
+  }
+}

--- a/apps/api/test/setup-e2e.ts
+++ b/apps/api/test/setup-e2e.ts
@@ -1,6 +1,4 @@
-import { execSync } from 'node:child_process';
-import { resolve, join } from 'node:path';
-import { existsSync } from 'node:fs';
+import { loadE2eEnv, hasDbResetCompleted, markDbResetCompleted, resetTestDb, shouldSkipDbReset } from './utils/reset-db';
 
 // Default e2e environment knobs
 // - Disable BullMQ queues unless a test explicitly enables them
@@ -10,67 +8,23 @@ if (!process.env.DISABLE_BULL) {
   process.env.DISABLE_BULL = '1';
 }
 
-// Load .env (root then app) to get DATABASE_URL_TEST if not provided
-try {
-  const dotenv = require('dotenv');
-  dotenv.config({ path: resolve(__dirname, '../../.env') });
-  dotenv.config({ path: resolve(__dirname, '../.env') });
-} catch {}
+loadE2eEnv();
 
-// Prefer test database for e2e
-if (process.env.DATABASE_URL_TEST) {
-  process.env.DATABASE_URL = process.env.DATABASE_URL_TEST;
-}
+// Avoid triggering DB resets multiple times when Jest spins up several workers.
+const globalSetupState = global as unknown as {
+  __E2E_DB_RESET_INITIALIZED__?: boolean;
+};
 
-// Helper to reset DB using Prisma migrate reset (force, no seed)
-function resetTestDb(label: string) {
-  if (!process.env.DATABASE_URL) return;
-  if (process.env.SKIP_DB_RESET === '1' || process.env.SKIP_DB_RESET === 'true') return;
-  try {
-    const apiDir = resolve(__dirname, '..');
-    const rootDir = resolve(apiDir, '..');
-    const prismaLocal = resolve(apiDir, 'node_modules', '.bin', process.platform === 'win32' ? 'prisma.cmd' : 'prisma');
-    const prismaRoot = resolve(rootDir, 'node_modules', '.bin', process.platform === 'win32' ? 'prisma.cmd' : 'prisma');
+if (!globalSetupState.__E2E_DB_RESET_INITIALIZED__) {
+  globalSetupState.__E2E_DB_RESET_INITIALIZED__ = true;
 
-    let prismaCmd: string | undefined;
-    if (existsSync(prismaLocal)) prismaCmd = `"${prismaLocal}"`;
-    else if (existsSync(prismaRoot)) prismaCmd = `"${prismaRoot}"`;
-
-    if (prismaCmd) {
-      execSync(`${prismaCmd} migrate reset --force --skip-seed --skip-generate`, {
-        cwd: apiDir,
-        stdio: 'pipe',
-        env: { ...process.env },
-      });
-      execSync(`${prismaCmd} migrate deploy`, {
-        cwd: apiDir,
-        stdio: 'pipe',
-        env: { ...process.env },
-      });
-    } else {
-      // Fallback to pnpm exec if local binary not found
-      execSync('pnpm exec prisma migrate reset --force --skip-seed --skip-generate', {
-        cwd: apiDir,
-        stdio: 'pipe',
-        env: { ...process.env },
-      });
-      execSync('pnpm exec prisma migrate deploy', {
-        cwd: apiDir,
-        stdio: 'pipe',
-        env: { ...process.env },
-      });
+  if (!hasDbResetCompleted()) {
+    const didReset = resetTestDb('setup-e2e');
+    if (didReset || shouldSkipDbReset()) {
+      markDbResetCompleted();
     }
-  } catch (err) {
-     
-    const msg = err instanceof Error ? err.message : String(err);
-    if (label === 'beforeAll') {
-      console.warn(`[e2e setup] DB reset failed during ${label}: ${msg}`);
-    } // be quiet during afterAll
   }
 }
-
-beforeAll(() => resetTestDb('beforeAll'));
-afterAll(() => resetTestDb('afterAll'));
 
 // Jest sometimes hangs due to unref'ed timers; ensure long timers don't block exit
 const _setTimeout: typeof setTimeout = global.setTimeout.bind(global);

--- a/apps/api/test/utils/reset-db.ts
+++ b/apps/api/test/utils/reset-db.ts
@@ -1,0 +1,113 @@
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const RESET_FLAG = 'E2E_DB_RESET_DONE';
+
+function getApiDir() {
+  return resolve(__dirname, '..', '..');
+}
+
+function getRepoRoot() {
+  return resolve(getApiDir(), '..', '..');
+}
+
+export function loadE2eEnv() {
+  try {
+    const dotenv = require('dotenv');
+    const apiDir = getApiDir();
+    const repoRoot = getRepoRoot();
+    const appsDir = resolve(apiDir, '..');
+
+    dotenv.config({ path: resolve(repoRoot, '.env') });
+    dotenv.config({ path: resolve(appsDir, '.env') });
+    dotenv.config({ path: resolve(apiDir, '.env') });
+  } catch {}
+
+  if (process.env.DATABASE_URL_TEST) {
+    process.env.DATABASE_URL = process.env.DATABASE_URL_TEST;
+  }
+}
+
+export function shouldSkipDbReset() {
+  const value = process.env.SKIP_DB_RESET;
+  if (!value) return false;
+  const normalized = value.toLowerCase();
+  return normalized === '1' || normalized === 'true';
+}
+
+export function hasDbResetCompleted() {
+  return process.env[RESET_FLAG] === '1';
+}
+
+export function markDbResetCompleted() {
+  process.env[RESET_FLAG] = '1';
+}
+
+export function clearDbResetFlag() {
+  delete process.env[RESET_FLAG];
+}
+
+function resolvePrismaCommand() {
+  const apiDir = getApiDir();
+  const repoRoot = getRepoRoot();
+  const prismaExecutable = process.platform === 'win32' ? 'prisma.cmd' : 'prisma';
+
+  const localBin = resolve(apiDir, 'node_modules', '.bin', prismaExecutable);
+  if (existsSync(localBin)) {
+    return `"${localBin}"`;
+  }
+
+  const rootBin = resolve(repoRoot, 'node_modules', '.bin', prismaExecutable);
+  if (existsSync(rootBin)) {
+    return `"${rootBin}"`;
+  }
+
+  return undefined;
+}
+
+export function resetTestDb(label: string, options?: { ignoreSkip?: boolean }) {
+  if (!process.env.DATABASE_URL) return false;
+  const ignoreSkip = options?.ignoreSkip ?? false;
+
+  if (!ignoreSkip && shouldSkipDbReset()) {
+    return false;
+  }
+
+  try {
+    const prismaCmd = resolvePrismaCommand();
+    const apiDir = getApiDir();
+
+    if (prismaCmd) {
+      execSync(`${prismaCmd} migrate reset --force --skip-seed --skip-generate`, {
+        cwd: apiDir,
+        stdio: 'pipe',
+        env: { ...process.env },
+      });
+      execSync(`${prismaCmd} migrate deploy`, {
+        cwd: apiDir,
+        stdio: 'pipe',
+        env: { ...process.env },
+      });
+    } else {
+      execSync('pnpm exec prisma migrate reset --force --skip-seed --skip-generate', {
+        cwd: apiDir,
+        stdio: 'pipe',
+        env: { ...process.env },
+      });
+      execSync('pnpm exec prisma migrate deploy', {
+        cwd: apiDir,
+        stdio: 'pipe',
+        env: { ...process.env },
+      });
+    }
+
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (label === 'globalSetup' || label === 'setup-e2e') {
+      console.warn(`[e2e setup] DB reset failed during ${label}: ${message}`);
+    }
+    return false;
+  }
+}

--- a/docs/api/PRISMA.md
+++ b/docs/api/PRISMA.md
@@ -19,6 +19,7 @@ This adds a production-ready Prisma bootstrapping layer to the NestJS API.
 - Unit: `pnpm --filter @influencerai/api test`
   - `PrismaService` connect/disconnect lifecycle, error propagation, shutdown hook wiring.
 - E2E: `pnpm --filter @influencerai/api test:e2e`
+  - Forza un reset completo del DB prima dell'esecuzione con `SKIP_DB_RESET=0 pnpm --filter @influencerai/api test:e2e`.
   - Health endpoint boots the app and verifies `{ status: 'ok', timestamp }`.
 
 ## Local run


### PR DESCRIPTION
## Summary
- add a reusable test database reset utility with shared dotenv loading
- wire Jest e2e global setup/teardown through ts-node wrappers and gate per-worker resets via a global flag
- document how to force a DB reset when running the API e2e suite

## Testing
- `pnpm --filter @influencerai/api test:e2e` *(fails: JwtAuthGuard cannot resolve JwtService in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e7e12a51c08320a4a7a8d8093ca593