### PR TITLE
Fix JSON parsing try-catch in content plan service

### DIFF
--- a/apps/api/src/content-plans/content-plans.service.ts
+++ b/apps/api/src/content-plans/content-plans.service.ts
@@ -82,8 +82,8 @@ export class ContentPlansService {
           } else {
             this.logger?.warn?.('OpenRouter posts validation failed, defaulting to empty array');
             normalized = [];
-        }
-      } catch {
+          }
+        } catch {
           this.logger?.warn?.('OpenRouter response content is not valid JSON array, defaulting to empty array');
           normalized = [];
         }


### PR DESCRIPTION
## Summary
- properly close the JSON parsing branch before the catch block in the content plan service
- ensure invalid JSON gracefully logs warnings and returns an empty array

## Testing
- pnpm --filter api build

------
https://chatgpt.com/codex/tasks/task_e_68e7e91688bc8320889e1aa2a8315fd0