### PR TITLE
Disable magic login in production

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -13,6 +13,12 @@
 
 Richiede `DATABASE_URL` configurata (in `apps/api/.env` o nella root `.env`).
 
+## Login "magico" (solo sviluppo/test)
+
+- L'endpoint `POST /auth/login` accetta il campo opzionale `magic` con il formato `tenantId:email` per ottenere un token JWT senza password durante lo sviluppo.
+- Quando `NODE_ENV=production` la rotta risponde `401 Unauthorized` e ignora completamente il campo `magic`.
+- Per gli ambienti produttivi usare esclusivamente le credenziali classiche (email/password).
+
 ### Tramite Docker Compose
 
 - Le migrazioni vengono applicate automaticamente al primo avvio tramite il servizio `api-migrate` definito in `infra/docker-compose.yml`.

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, UnauthorizedException } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { Public } from './public.decorator';
@@ -14,7 +14,12 @@ export class AuthController {
     const email = String(body?.email || '');
     const password = String(body?.password || '');
     const magic = String(body?.magic || '');
-    if (magic) return this.auth.loginWithMagicToken(magic);
+    if (magic) {
+      if (!this.auth.isMagicLoginEnabled()) {
+        throw new UnauthorizedException('Magic login is disabled in production');
+      }
+      return this.auth.loginWithMagicToken(magic);
+    }
     return this.auth.loginWithPassword(email, password);
   }
 }

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -1,0 +1,45 @@
+import { AuthService } from './auth.service';
+
+describe('AuthService - magic login', () => {
+  const prisma: any = { user: { findFirst: jest.fn() } };
+  const jwt: any = { signAsync: jest.fn() };
+  let service: AuthService;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    prisma.user.findFirst.mockReset();
+    jwt.signAsync.mockReset();
+    service = new AuthService(prisma, jwt);
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterAll(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it('allows magic login outside production', async () => {
+    const user = { id: 'user-1', tenantId: 'tenant-1', email: 'test@example.com', role: 'admin' };
+    prisma.user.findFirst.mockResolvedValue(user);
+    jwt.signAsync.mockResolvedValue('signed');
+
+    await expect(service.loginWithMagicToken('tenant-1:test@example.com')).resolves.toEqual({ access_token: 'signed' });
+
+    expect(prisma.user.findFirst).toHaveBeenCalledWith({ where: { tenantId: 'tenant-1', email: 'test@example.com' } });
+    expect(jwt.signAsync).toHaveBeenCalledWith({ sub: 'user-1', tenantId: 'tenant-1', email: 'test@example.com', role: 'admin' });
+  });
+
+  it('blocks magic login in production', async () => {
+    process.env.NODE_ENV = 'production';
+
+    await expect(service.loginWithMagicToken('tenant-1:test@example.com')).rejects.toThrow(
+      'Magic login is disabled in production',
+    );
+
+    expect(prisma.user.findFirst).not.toHaveBeenCalled();
+    expect(jwt.signAsync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -22,7 +22,14 @@ export class AuthService {
     return { access_token };
   }
 
+  isMagicLoginEnabled() {
+    return process.env.NODE_ENV !== 'production';
+  }
+
   async loginWithMagicToken(token: string) {
+    if (!this.isMagicLoginEnabled()) {
+      throw new UnauthorizedException('Magic login is disabled in production');
+    }
     // For dev only: token format tenantId:email
     const [tenantId, email] = String(token || '').split(':');
     if (!tenantId || !email) throw new UnauthorizedException('Invalid token');


### PR DESCRIPTION
## Summary
- block magic token authentication when NODE_ENV is production and expose a helper to check availability
- add unit tests covering both allowed and blocked magic login flows
- document the development-only usage of magic login in the API README

## Testing
- pnpm --filter @influencerai/api test

------
https://chatgpt.com/codex/tasks/task_e_68e7eac6d1d08320b16440ded45fbd6d