### PR TITLE
Fix badge markup in queues widget

### DIFF
--- a/apps/web/src/components/QueuesWidget.tsx
+++ b/apps/web/src/components/QueuesWidget.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 
+import { Badge, type BadgeProps } from "@/components/ui/badge";
 import {
   Card,
   CardContent,
@@ -24,7 +25,7 @@ type StatDefinition = {
   key: keyof QueueStats;
   label: string;
   description: string;
-  badgeVariant: "info" | "secondary" | "destructive";
+  badgeVariant: NonNullable<BadgeProps["variant"]>;
 };
 
 const STAT_DEFINITION: StatDefinition[] = [
@@ -32,7 +33,7 @@ const STAT_DEFINITION: StatDefinition[] = [
     key: "active",
     label: "Attivi",
     description: "Job in elaborazione",
-    badgeVariant: "info",
+    badgeVariant: "brand",
   },
   {
     key: "waiting",
@@ -93,11 +94,13 @@ export function QueuesWidget() {
         )}
         {stats && (
           <dl className="grid grid-cols-1 gap-4 md:grid-cols-3" aria-live="polite">
-            {stats.map(({ key, label, description, accentClass, value }) => (
+            {stats.map(({ key, label, description, badgeVariant, value }) => (
               <div key={key} className="rounded-lg border border-border/60 bg-background/60 p-4">
                 <dt className="text-sm font-medium text-muted-foreground">{label}</dt>
                 <dd className="mt-3 text-3xl font-semibold text-foreground">
-                  <span className={cn("inline-flex rounded-full border px-3 py-1 text-base", accentClass)}>
+                  <Badge
+                    variant={badgeVariant}
+                    className={cn("px-3 py-1 text-base leading-tight")}>
                     {numberFormatter.format(value)}
                   </Badge>
                 </dd>


### PR DESCRIPTION
## Summary
- replace the incorrect span markup in the queues widget with the shared Badge component
- align the stat definitions and renderer to use Badge variants consistently

## Testing
- pnpm build --filter @influencerai/web *(fails: missing `lucide-react` dependency and offline font download)*

------
https://chatgpt.com/codex/tasks/task_e_68e7f919fefc8320a652c8ac0fca30d5