### PR TITLE
Add job outcome series endpoint

### DIFF
--- a/apps/api/src/jobs/dto.ts
+++ b/apps/api/src/jobs/dto.ts
@@ -4,6 +4,20 @@ export const JobTypeSchema = z.enum(['content-generation', 'lora-training', 'vid
 
 export const JobStatusSchema = z.enum(['pending', 'running', 'succeeded', 'failed', 'completed']);
 
+const windowRegex = /^\d+(?:m|h|d)$/i;
+
+export const JobSeriesQuerySchema = z.object({
+  window: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .regex(windowRegex, 'Invalid window format. Use values like 1h or 24h.')
+    .optional()
+    .default('24h'),
+});
+
+export type JobSeriesQuery = z.infer<typeof JobSeriesQuerySchema>;
+
 export const CreateJobSchema = z.object({
   type: JobTypeSchema,
   payload: z.record(z.any()),

--- a/apps/api/src/jobs/jobs.controller.ts
+++ b/apps/api/src/jobs/jobs.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, Param, Post, Body, Query, BadRequestException, NotFoundException, Patch } from '@nestjs/common';
 import { JobsService } from './jobs.service';
-import { CreateJobSchema, ListJobsQuerySchema, UpdateJobSchema } from './dto';
+import { CreateJobSchema, JobSeriesQuerySchema, ListJobsQuerySchema, UpdateJobSchema } from './dto';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('jobs')
@@ -34,6 +34,17 @@ export class JobsController {
       throw new BadRequestException(parsed.error.flatten());
     }
     return this.jobsService.listJobs(parsed.data);
+  }
+
+  @Get('series')
+  @ApiOperation({ summary: 'Get aggregated job outcomes over time' })
+  @ApiResponse({ status: 200, description: 'Aggregated job series' })
+  series(@Query('window') window?: string) {
+    const parsed = JobSeriesQuerySchema.safeParse({ window });
+    if (!parsed.success) {
+      throw new BadRequestException(parsed.error.flatten());
+    }
+    return this.jobsService.getJobSeries(parsed.data);
   }
 
   @Get(':id')

--- a/apps/api/src/jobs/jobs.service.spec.ts
+++ b/apps/api/src/jobs/jobs.service.spec.ts
@@ -1,30 +1,79 @@
-﻿import { Test } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Queue } from 'bullmq';
 import { JobsService } from './jobs.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { Queue } from 'bullmq';
-
-const queueMock = { add: jest.fn().mockResolvedValue(null) } as Pick<Queue, 'add'>;
+import { JobSeriesQuerySchema } from './dto';
 
 describe('JobsService', () => {
-  it('creates job and enqueues', async () => {
+  const queueMock = { add: jest.fn().mockResolvedValue(null) } as Pick<Queue, 'add'>;
+  let prismaMock: { job: { create: jest.Mock }; $queryRawUnsafe: jest.Mock };
+  let service: JobsService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    prismaMock = {
+      job: { create: jest.fn().mockResolvedValue({ id: 'j1', type: 'content-generation' }) },
+      $queryRawUnsafe: jest.fn().mockResolvedValue([]),
+    } as any;
+
     const moduleRef = await Test.createTestingModule({
       providers: [
         JobsService,
-        { provide: PrismaService, useValue: { job: { create: jest.fn().mockResolvedValue({ id: 'j1', type: 'content-generation' }) } } },
+        { provide: PrismaService, useValue: prismaMock },
         { provide: 'BullQueue_content-generation', useValue: queueMock },
         { provide: 'BullQueue_lora-training', useValue: queueMock },
         { provide: 'BullQueue_video-generation', useValue: queueMock },
       ],
     }).compile();
 
-    const svc = moduleRef.get(JobsService);
-    const job = await svc.createJob({ type: 'content-generation', payload: { foo: 'bar' } });
+    service = moduleRef.get(JobsService);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('creates job and enqueues', async () => {
+    const job = await service.createJob({ type: 'content-generation', payload: { foo: 'bar' } });
 
     expect(job.id).toBe('j1');
     expect(queueMock.add).toHaveBeenCalledWith(
       'content-generation',
       expect.objectContaining({ jobId: 'j1', payload: { foo: 'bar' } }),
-      expect.any(Object)
+      expect.any(Object),
     );
+  });
+
+  it('aggregates job results according to window', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-05-15T12:34:56.000Z'));
+
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { bucket: new Date('2024-05-15T10:00:00.000Z'), success: 2n, failed: 1n },
+      { bucket: new Date('2024-05-15T12:00:00.000Z'), success: 1n, failed: 0n },
+    ]);
+
+    const result = await service.getJobSeries({ window: '3h' });
+
+    expect(prismaMock.$queryRawUnsafe).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      { t: '2024-05-15T10:00:00.000Z', success: 2, failed: 1 },
+      { t: '2024-05-15T11:00:00.000Z', success: 0, failed: 0 },
+      { t: '2024-05-15T12:00:00.000Z', success: 1, failed: 0 },
+    ]);
+  });
+
+  it('rejects invalid window format', async () => {
+    await expect(service.getJobSeries({ window: 'abc' as any })).rejects.toThrow('Invalid window format');
+  });
+});
+
+describe('JobSeriesQuerySchema', () => {
+  it('applies default window when omitted', () => {
+    expect(JobSeriesQuerySchema.parse({})).toEqual({ window: '24h' });
+  });
+
+  it('flags invalid window values', () => {
+    const result = JobSeriesQuerySchema.safeParse({ window: '5x' });
+    expect(result.success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add a Zod schema for the jobs series window parameter with a default fallback
- implement job outcome aggregation per time window and expose it through GET /jobs/series
- cover window validation and aggregation behaviour with new unit tests

## Testing
- pnpm --filter @influencerai/api test

------
https://chatgpt.com/codex/tasks/task_e_68e7f914053483209312b38e280dd416