### PR TITLE
Add video-generation worker processor

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -1,6 +1,6 @@
 Worker (BullMQ)
 
-- Purpose: process queues `content-generation` and `lora-training` and sync job status to the API.
+- Purpose: process queues `content-generation`, `video-generation` and `lora-training` and sync job status to the API.
 
 Env variables
 - `API_BASE_URL` or `WORKER_API_URL`: base URL of API (default `http://localhost:3001`).
@@ -8,14 +8,32 @@ Env variables
 - `BULL_PREFIX`: optional Redis key prefix to isolate queues per env/test.
 - `WORKER_JOB_ATTEMPTS`: number of attempts when enqueuing jobs from API (default 3; configured in API).
 - `WORKER_JOB_BACKOFF_DELAY_MS`: backoff base delay for retries (default 5000; configured in API).
+- `COMFYUI_API_URL`: base URL of ComfyUI REST server (default `http://127.0.0.1:8188`).
+- `COMFYUI_CLIENT_ID`: identifier passed to ComfyUI prompt submissions (default `influencerai-worker`).
+- `COMFYUI_TIMEOUT_MS`: HTTP timeout for ComfyUI requests (default `120000`).
+- `COMFYUI_POLL_INTERVAL_MS`: delay between polling attempts for ComfyUI job status (default `5000`).
+- `COMFYUI_MAX_POLL_ATTEMPTS`: max polling attempts before failing (default `120`).
+- `COMFYUI_VIDEO_WORKFLOW_JSON`: optional JSON string merged into the prompt payload (e.g. serialized workflow graph).
+- `FFMPEG_PATH`: path to ffmpeg binary (default `ffmpeg`).
+- `FFMPEG_ASPECT_RATIO`: desired output aspect ratio (default `9:16`).
+- `FFMPEG_AUDIO_FILTER`: ffmpeg audio filter applied during post-processing (default `loudnorm=I=-16:TP=-1.5:LRA=11`).
+- `FFMPEG_VIDEO_PRESET`: ffmpeg preset for libx264 encoding (default `medium`).
 
 Behavior
 - On job start: PATCH `/jobs/:id` with `status=running`.
 - On success: PATCH with `status=succeeded` and a result payload.
 - On failure: PATCH with `status=failed` and error info.
 - Lightweight internal retry is applied for PATCH requests.
+- Video jobs submit prompts to ComfyUI, poll `/history/:promptId`, post-process the output with FFmpeg and upload the final MP4 to MinIO (signed URLs are attached to the job result).
 
 Run locally
 - Ensure Redis is running.
 - Build SDK if not built: `pnpm --filter @influencerai/sdk build`.
 - Dev: `pnpm --filter @influencerai/worker dev`.
+
+Manual test with ComfyUI
+1. Export the ComfyUI workflow graph you want to use and serialize it as JSON. Set the env var `COMFYUI_VIDEO_WORKFLOW_JSON` with that JSON string (or tailor the processor to inject node inputs downstream).
+2. Start ComfyUI with the REST server enabled (default `http://127.0.0.1:8188`).
+3. Run `pnpm --filter @influencerai/worker dev` and enqueue a `video-generation` job via the API (payload requires `caption`, `script`, optional persona/context/duration).
+4. The worker logs the ComfyUI prompt id, polls until completion, then runs FFmpeg with the configured aspect ratio/audio filter.
+5. Verify the processed video is uploaded to MinIO under `video-generation/<jobId>/final.mp4` and that the signed URL appears in the job result.

--- a/apps/worker/src/processors/videoGeneration.test.ts
+++ b/apps/worker/src/processors/videoGeneration.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createVideoGenerationProcessor } from './videoGeneration';
+import { promises as fs } from 'fs';
+
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+function createResponse(body: BodyInit, init?: ResponseInit) {
+  return new Response(body, init);
+}
+
+describe('video-generation processor', () => {
+  it('calls ComfyUI, runs ffmpeg, uploads to S3 and patches status', async () => {
+    const patchCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
+    const uploaded: Array<{ key: string; body: Buffer; contentType?: string }> = [];
+    let historyCalls = 0;
+    const fetchSpy = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input.endsWith('/prompt')) {
+        expect(init?.method).toBe('POST');
+        const body = init?.body as string;
+        const parsed = JSON.parse(body);
+        expect(parsed.prompt.inputs.caption).toBe('Caption');
+        expect(parsed.prompt.inputs.script).toBe('Script');
+        return createResponse(JSON.stringify({ prompt_id: 'job-123' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (input.includes('/history/job-123')) {
+        historyCalls += 1;
+        if (historyCalls === 1) {
+          return createResponse(JSON.stringify({ job: { status: { status: 'running' } } }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return createResponse(
+          JSON.stringify({
+            'job-123': {
+              status: { status: 'completed', completed: true },
+              outputs: {
+                video: [
+                  {
+                    filename: 'output.mp4',
+                    subfolder: 'videos',
+                    type: 'output',
+                  },
+                ],
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+      if (input.includes('/view')) {
+        return createResponse(Buffer.from('raw-video'), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch ${input}`);
+    });
+
+    const processor = createVideoGenerationProcessor({
+      logger: noopLogger,
+      patchJobStatus: async (id, data) => {
+        patchCalls.push({ id, data });
+      },
+      s3: {
+        getClient: () => ({ client: {}, bucket: 'bucket' }),
+        putBinaryObject: async (_client, _bucket, key, body, contentType) => {
+          const buffer = Buffer.isBuffer(body) ? body : Buffer.from(body as Uint8Array);
+          uploaded.push({ key, body: buffer, contentType });
+        },
+        putTextObject: async () => {},
+        getSignedGetUrl: async (_client, _bucket, key) => `https://example.com/${key}`,
+      },
+      comfy: {
+        baseUrl: 'http://localhost:8188',
+        clientId: 'test-client',
+        fetch: fetchSpy,
+        pollIntervalMs: 1,
+        maxPollAttempts: 5,
+      },
+      ffmpeg: {
+        aspectRatio: '9:16',
+        audioFilter: 'loudnorm',
+        preset: 'medium',
+        run: async ({ inputPath, outputPath }) => {
+          const data = await fs.readFile(inputPath);
+          await fs.writeFile(outputPath, Buffer.concat([data, Buffer.from('-processed')]));
+        },
+      },
+    });
+
+    const result = await processor({
+      id: 'queue-1',
+      name: 'video-job',
+      data: {
+        jobId: 'job-1',
+        payload: {
+          caption: ' Caption ',
+          script: ' Script ',
+          context: 'launch',
+          durationSec: 30,
+          persona: { name: 'Ava' },
+        },
+      },
+    } as any);
+
+    expect(result.success).toBe(true);
+    expect(result.videoUrl).toBe('https://example.com/video-generation/job-1/final.mp4');
+    expect(uploaded).toHaveLength(1);
+    expect(uploaded[0]?.key).toBe('video-generation/job-1/final.mp4');
+    expect(uploaded[0]?.body.toString()).toContain('processed');
+    expect(patchCalls.map((c) => c.data.status)).toEqual(['running', 'succeeded']);
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it('reports ComfyUI failures via patchJobStatus', async () => {
+    const patchCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
+    const fetchSpy = vi.fn(async (input: string) => {
+      if (input.endsWith('/prompt')) {
+        return createResponse(JSON.stringify({ prompt_id: 'job-err' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (input.includes('/history/job-err')) {
+        return createResponse(
+          JSON.stringify({
+            'job-err': {
+              status: { status: 'error', error: 'Out of memory' },
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      throw new Error('Unexpected fetch');
+    });
+
+    const processor = createVideoGenerationProcessor({
+      logger: noopLogger,
+      patchJobStatus: async (id, data) => {
+        patchCalls.push({ id, data });
+      },
+      s3: {
+        getClient: () => null,
+        putBinaryObject: async () => {
+          throw new Error('Should not upload');
+        },
+        putTextObject: async () => {},
+        getSignedGetUrl: async () => '',
+      },
+      comfy: {
+        baseUrl: 'http://localhost:8188',
+        clientId: 'test-client',
+        fetch: fetchSpy,
+        pollIntervalMs: 1,
+        maxPollAttempts: 2,
+      },
+      ffmpeg: {
+        aspectRatio: '9:16',
+        audioFilter: 'loudnorm',
+        preset: 'medium',
+        run: async () => {
+          throw new Error('Should not run ffmpeg');
+        },
+      },
+    });
+
+    await expect(
+      processor({
+        id: 'queue-err',
+        name: 'video-job',
+        data: {
+          jobId: 'job-err',
+          payload: {
+            caption: 'caption',
+            script: 'script',
+          },
+        },
+      } as any)
+    ).rejects.toThrow(/Out of memory/);
+
+    expect(patchCalls).toHaveLength(2);
+    expect(patchCalls[0]).toEqual({ id: 'job-err', data: { status: 'running' } });
+    expect(patchCalls[1]?.data?.status).toBe('failed');
+  });
+});

--- a/apps/worker/src/processors/videoGeneration.ts
+++ b/apps/worker/src/processors/videoGeneration.ts
@@ -1,0 +1,411 @@
+import type { Job, Processor } from 'bullmq';
+import type { Logger } from 'pino';
+import type { S3Client } from '@aws-sdk/client-s3';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import type { PatchJobStatus } from './contentGeneration';
+
+type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+type ComfyOutputAsset = {
+  filename?: string;
+  subfolder?: string;
+  type?: string;
+  url?: string;
+};
+
+type S3ClientInfo = { client: S3Client; bucket: string };
+
+export type S3Helper = {
+  getClient: (logger?: Pick<Logger, 'info' | 'warn' | 'error'>) => S3ClientInfo | null;
+  putBinaryObject: (
+    client: S3Client,
+    bucket: string,
+    key: string,
+    body: NodeJS.ReadableStream | Uint8Array | Buffer,
+    contentType?: string
+  ) => Promise<void>;
+  putTextObject: (client: S3Client, bucket: string, key: string, content: string) => Promise<void>;
+  getSignedGetUrl: (client: S3Client, bucket: string, key: string, expiresInSeconds?: number) => Promise<string>;
+};
+
+export type VideoGenerationDependencies = {
+  logger: Pick<Logger, 'info' | 'warn' | 'error'>;
+  patchJobStatus: PatchJobStatus;
+  s3: S3Helper;
+  comfy: {
+    baseUrl: string;
+    clientId: string;
+    fetch: FetchLike;
+    workflowPayload?: Record<string, unknown>;
+    pollIntervalMs?: number;
+    maxPollAttempts?: number;
+  };
+  ffmpeg: {
+    aspectRatio: string;
+    audioFilter: string;
+    preset: string;
+    run: (input: { inputPath: string; outputPath: string; aspectRatio: string; audioFilter: string; preset: string }) => Promise<void>;
+  };
+};
+
+export type VideoGenerationPayload = {
+  caption?: string;
+  script?: string;
+  persona?: unknown;
+  context?: string;
+  durationSec?: number;
+};
+
+export type VideoGenerationJobData = {
+  jobId?: string;
+  payload?: VideoGenerationPayload;
+};
+
+export type VideoGenerationResult = {
+  success: true;
+  comfyJobId: string;
+  caption: string;
+  script: string;
+  context?: string;
+  persona?: unknown;
+  durationSec: number;
+  videoKey?: string;
+  videoUrl?: string;
+};
+
+export type VideoGenerationJob = Job<VideoGenerationJobData, VideoGenerationResult, 'video-generation'>;
+
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+const DEFAULT_MAX_ATTEMPTS = 120;
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+function cloneWorkflowPayload(payload?: Record<string, unknown>) {
+  if (!payload) return undefined;
+  return JSON.parse(JSON.stringify(payload)) as Record<string, unknown>;
+}
+
+function attachPromptMetadata(
+  base: Record<string, unknown> | undefined,
+  metadata: Record<string, unknown>,
+  inputs: Record<string, unknown>
+) {
+  const prompt = base ? { ...base } : {};
+  const existingInputs = (prompt.inputs as Record<string, unknown> | undefined) ?? {};
+  prompt.inputs = { ...existingInputs, ...inputs };
+
+  const extraData = (prompt.extra_data as Record<string, unknown> | undefined) ?? {};
+  const existingMeta = (extraData.metadata as Record<string, unknown> | undefined) ?? {};
+  extraData.metadata = { ...existingMeta, ...metadata };
+  prompt.extra_data = extraData;
+
+  return prompt;
+}
+
+function extractVideoAsset(history: any): ComfyOutputAsset | null {
+  const outputs = history?.outputs;
+  if (!outputs || typeof outputs !== 'object') return null;
+
+  const outputArrays = Object.values(outputs).filter(Array.isArray) as ComfyOutputAsset[][];
+  for (const arr of outputArrays) {
+    for (const entry of arr) {
+      if (!entry || typeof entry !== 'object') continue;
+      if (entry.type === 'video' || entry.type === 'output' || entry.url || (entry.filename && entry.filename.endsWith('.mp4'))) {
+        return entry;
+      }
+    }
+  }
+  return null;
+}
+
+function buildAssetUrl(baseUrl: string, asset: ComfyOutputAsset): string {
+  if (asset.url) {
+    const trimmed = asset.url.trim();
+    if (/^https?:/i.test(trimmed)) return trimmed;
+    const base = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    return `${base}/${trimmed.replace(/^\//, '')}`;
+  }
+
+  const filename = asset.filename;
+  if (!filename) {
+    throw new Error('ComfyUI output is missing filename');
+  }
+  const subfolder = asset.subfolder ?? '';
+  const type = asset.type ?? 'output';
+  const url = new URL('/view', baseUrl);
+  url.searchParams.set('filename', filename);
+  url.searchParams.set('subfolder', subfolder);
+  url.searchParams.set('type', type);
+  return url.toString();
+}
+
+function parseHistoryState(history: any) {
+  if (!history || typeof history !== 'object') {
+    return { state: 'running' as const };
+  }
+
+  const status = history.status ?? history;
+  const statusText = typeof status?.status === 'string' ? status.status.toLowerCase() : undefined;
+  const completed = status?.completed === true || statusText === 'completed' || statusText === 'success';
+  const failed = statusText === 'error' || statusText === 'failed' || statusText === 'cancelled' || status?.failed === true;
+  const error = status?.error ?? status?.err ?? status?.message;
+
+  if (failed) {
+    return { state: 'failed' as const, error: typeof error === 'string' ? error : 'ComfyUI job failed' };
+  }
+
+  if (completed) {
+    return { state: 'succeeded' as const };
+  }
+
+  if (typeof error === 'string' && error.trim()) {
+    return { state: 'failed' as const, error };
+  }
+
+  return { state: 'running' as const };
+}
+
+export function createVideoGenerationProcessor(deps: VideoGenerationDependencies) {
+  const processor: Processor<VideoGenerationJobData, VideoGenerationResult, 'video-generation'> = async function process(
+    job: VideoGenerationJob
+  ) {
+    const { logger, patchJobStatus, s3, comfy, ffmpeg } = deps;
+
+    logger.info({ id: job.id, name: job.name, data: job.data }, 'Processing video-generation job');
+
+    const jobData = job.data ?? {};
+    const jobId = typeof jobData.jobId === 'string' ? jobData.jobId : undefined;
+    const payload = (jobData.payload ?? {}) as VideoGenerationPayload;
+
+    const caption = typeof payload.caption === 'string' ? payload.caption.trim() : '';
+    const script = typeof payload.script === 'string' ? payload.script.trim() : '';
+    const context = typeof payload.context === 'string' ? payload.context : undefined;
+    const persona = payload.persona;
+    const personaText =
+      typeof payload.persona === 'string'
+        ? payload.persona
+        : payload.persona
+        ? JSON.stringify(payload.persona)
+        : undefined;
+    const durationCandidate = Number(payload.durationSec ?? 0);
+    const durationSec = Number.isFinite(durationCandidate) && durationCandidate > 0 ? durationCandidate : 15;
+
+    if (!caption || !script) {
+      const err = new Error('Video generation payload requires caption and script');
+      if (jobId) {
+        await patchJobStatus(jobId, {
+          status: 'failed',
+          result: { message: err.message },
+        });
+      }
+      throw err;
+    }
+
+    if (jobId) {
+      await patchJobStatus(jobId, { status: 'running' });
+    }
+
+    const pollIntervalMs = comfy.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const maxPollAttempts = comfy.maxPollAttempts ?? DEFAULT_MAX_ATTEMPTS;
+    const fetchFn = comfy.fetch;
+    const metadata = {
+      jobId,
+      queueJobId: job.id,
+      caption,
+      script,
+      persona: personaText ?? persona,
+      context,
+      durationSec,
+    };
+
+    let comfyJobId: string | undefined;
+    let tempDir: string | undefined;
+
+    try {
+      const promptPayload = attachPromptMetadata(
+        cloneWorkflowPayload(comfy.workflowPayload),
+        metadata,
+        {
+          caption,
+          script,
+          persona,
+          personaText,
+          context,
+          durationSec,
+        }
+      );
+
+      const requestBody = {
+        client_id: comfy.clientId,
+        prompt: promptPayload,
+      } as Record<string, unknown>;
+
+      logger.info({ jobId, comfyRequest: { clientId: comfy.clientId } }, 'Submitting ComfyUI prompt');
+
+      const res = await fetchFn(`${comfy.baseUrl.replace(/\/$/, '')}/prompt`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!res.ok) {
+        throw new Error(`ComfyUI prompt failed with status ${res.status}`);
+      }
+
+      let json: any = null;
+      try {
+        json = await res.json();
+      } catch {
+        json = null;
+      }
+
+      comfyJobId =
+        (json?.prompt_id as string | undefined) || (json?.id as string | undefined) || (json?.job_id as string | undefined);
+
+      if (!comfyJobId) {
+        throw new Error('ComfyUI prompt response missing job identifier');
+      }
+
+      logger.info({ jobId, comfyJobId }, 'ComfyUI prompt accepted');
+
+      let attempt = 0;
+      let finalHistory: any = null;
+
+      while (attempt < maxPollAttempts) {
+        attempt += 1;
+        const historyRes = await fetchFn(`${comfy.baseUrl.replace(/\/$/, '')}/history/${encodeURIComponent(comfyJobId)}`);
+        if (historyRes.status === 404) {
+          await sleep(pollIntervalMs);
+          continue;
+        }
+
+        if (!historyRes.ok) {
+          throw new Error(`ComfyUI history request failed with status ${historyRes.status}`);
+        }
+
+        let historyJson: any;
+        try {
+          historyJson = await historyRes.json();
+        } catch (err) {
+          logger.warn({ err }, 'Unable to parse ComfyUI history response');
+          await sleep(pollIntervalMs);
+          continue;
+        }
+
+        const historyEntry = historyJson?.[comfyJobId] ?? historyJson;
+        finalHistory = historyEntry;
+        const state = parseHistoryState(historyEntry);
+
+        logger.info({ jobId, comfyJobId, attempt, state: state.state }, 'Polled ComfyUI job');
+
+        if (state.state === 'failed') {
+          throw new Error(state.error || 'ComfyUI job failed');
+        }
+
+        if (state.state === 'succeeded') {
+          break;
+        }
+
+        await sleep(pollIntervalMs);
+      }
+
+      if (!finalHistory) {
+        throw new Error('Timed out waiting for ComfyUI job history');
+      }
+
+      const finalState = parseHistoryState(finalHistory);
+      if (finalState.state !== 'succeeded') {
+        throw new Error('ComfyUI job did not complete successfully');
+      }
+
+      const asset = extractVideoAsset(finalHistory);
+      if (!asset) {
+        throw new Error('ComfyUI history did not contain a video output');
+      }
+
+      const assetUrl = buildAssetUrl(comfy.baseUrl, asset);
+      logger.info({ jobId, comfyJobId, assetUrl }, 'Downloading ComfyUI video output');
+
+      const downloadRes = await fetchFn(assetUrl);
+      if (!downloadRes.ok) {
+        throw new Error(`Failed to download ComfyUI output (${downloadRes.status})`);
+      }
+
+      const arrayBuffer = await downloadRes.arrayBuffer();
+      const buffer = Buffer.from(arrayBuffer);
+
+      tempDir = await mkdtemp(path.join(tmpdir(), 'video-generation-'));
+      const rawPath = path.join(tempDir, 'raw.mp4');
+      const processedPath = path.join(tempDir, 'processed.mp4');
+
+      await writeFile(rawPath, buffer);
+
+      await ffmpeg.run({
+        inputPath: rawPath,
+        outputPath: processedPath,
+        aspectRatio: ffmpeg.aspectRatio,
+        audioFilter: ffmpeg.audioFilter,
+        preset: ffmpeg.preset,
+      });
+
+      const processedBuffer = await readFile(processedPath);
+
+      const s3ClientInfo = s3.getClient(logger);
+      let videoKey: string | undefined;
+      let videoUrl: string | undefined;
+
+      if (s3ClientInfo) {
+        const jobIdentifier = jobId || String(job.id);
+        const baseKey = `video-generation/${jobIdentifier}/`;
+        videoKey = `${baseKey}final.mp4`;
+        await s3.putBinaryObject(s3ClientInfo.client, s3ClientInfo.bucket, videoKey, processedBuffer, 'video/mp4');
+        try {
+          videoUrl = await s3.getSignedGetUrl(s3ClientInfo.client, s3ClientInfo.bucket, videoKey, 7 * 24 * 3600);
+        } catch (err) {
+          logger.warn({ err }, 'Failed to generate signed URL for video');
+        }
+      } else {
+        logger.warn('S3 client unavailable, skipping upload of video output');
+      }
+
+      const result: VideoGenerationResult = {
+        success: true,
+        comfyJobId,
+        caption,
+        script,
+        context,
+        persona,
+        durationSec,
+        videoKey,
+        videoUrl,
+      };
+
+      if (jobId) {
+        const { success: _success, ...jobResult } = result;
+        void _success;
+        await patchJobStatus(jobId, { status: 'succeeded', result: jobResult });
+      }
+
+      return result;
+    } catch (err) {
+      logger.error({ err, jobId, comfyJobId }, 'video-generation processor error');
+      if (jobId) {
+        await patchJobStatus(jobId, {
+          status: 'failed',
+          result: { message: (err as any)?.message, stack: (err as any)?.stack },
+        });
+      }
+      throw err;
+    } finally {
+      if (tempDir) {
+        await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      }
+    }
+  };
+
+  return processor;
+}

--- a/backlog/issues.yaml
+++ b/backlog/issues.yaml
@@ -463,10 +463,10 @@ issues:
 - title: 'WORK-05: Pipeline video con ComfyUI e FFmpeg'
   body: "### Contesto\nLa README descrive generazione video ma il worker non integra\
     \ ComfyUI né FFmpeg. Va creato un processor che interagisce con le API locali\
-    \ di ComfyUI e normalizza i file video finali.\n\n### DoD\n- [ ] Job video-generation\
-    \ che chiama ComfyUI REST e gestisce il polling dello stato.\n- [ ] Post-processing\
-    \ FFmpeg (aspect ratio, audio leveling) configurabile.\n- [ ] Asset video caricati\
-    \ su MinIO e registrati nel DB.\n- [ ] Test manuale con ComfyUI locale documentato.\n\
+    \ di ComfyUI e normalizza i file video finali.\n\n### DoD\n- [x] Job video-generation\
+    \ che chiama ComfyUI REST e gestisce il polling dello stato.\n- [x] Post-processing\
+    \ FFmpeg (aspect ratio, audio leveling) configurabile.\n- [x] Asset video caricati\
+    \ su MinIO e registrati nel DB.\n- [x] Test manuale con ComfyUI locale documentato.\n\
     \n### Dipendenze\n- [WORK-01] Sincronizzare stato job con l'API\n- [API-05] Dataset\
     \ ingestion e storage su MinIO\n"
   labels:


### PR DESCRIPTION
## Summary
- add a dedicated video-generation processor that submits prompts to ComfyUI, polls job completion, post-processes with FFmpeg, and uploads the final asset to MinIO
- wire the new worker into the worker entrypoint with FFmpeg runner utilities and runtime configuration
- cover the processor with unit tests and document the new environment variables / DoD updates

## Testing
- pnpm --filter @influencerai/worker test

------
https://chatgpt.com/codex/tasks/task_e_68e7fdc75cf0832098fa7bb196dad3fd