### PR TITLE
Refactor video generation processor helpers into modules

### DIFF
--- a/apps/worker/src/processors/videoGeneration.ts
+++ b/apps/worker/src/processors/videoGeneration.ts
@@ -1,179 +1,34 @@
-import type { Job, Processor } from 'bullmq';
-import type { Logger } from 'pino';
-import type { S3Client } from '@aws-sdk/client-s3';
+import type { Processor } from 'bullmq';
 import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import path from 'path';
-import type { PatchJobStatus } from './contentGeneration';
 
-type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+import { createComfyClient } from './videoGeneration/comfyClient';
+import type {
+  VideoGenerationDependencies,
+  VideoGenerationJob,
+  VideoGenerationJobData,
+  VideoGenerationPayload,
+  VideoGenerationResult,
+} from './videoGeneration/types';
 
-type ComfyOutputAsset = {
-  filename?: string;
-  subfolder?: string;
-  type?: string;
-  url?: string;
-};
+export type {
+  VideoGenerationDependencies,
+  VideoGenerationJob,
+  VideoGenerationJobData,
+  VideoGenerationPayload,
+  VideoGenerationResult,
+} from './videoGeneration/types';
 
-type S3ClientInfo = { client: S3Client; bucket: string };
-
-export type S3Helper = {
-  getClient: (logger?: Pick<Logger, 'info' | 'warn' | 'error'>) => S3ClientInfo | null;
-  putBinaryObject: (
-    client: S3Client,
-    bucket: string,
-    key: string,
-    body: NodeJS.ReadableStream | Uint8Array | Buffer,
-    contentType?: string
-  ) => Promise<void>;
-  putTextObject: (client: S3Client, bucket: string, key: string, content: string) => Promise<void>;
-  getSignedGetUrl: (client: S3Client, bucket: string, key: string, expiresInSeconds?: number) => Promise<string>;
-};
-
-export type VideoGenerationDependencies = {
-  logger: Pick<Logger, 'info' | 'warn' | 'error'>;
-  patchJobStatus: PatchJobStatus;
-  s3: S3Helper;
-  comfy: {
-    baseUrl: string;
-    clientId: string;
-    fetch: FetchLike;
-    workflowPayload?: Record<string, unknown>;
-    pollIntervalMs?: number;
-    maxPollAttempts?: number;
-  };
-  ffmpeg: {
-    aspectRatio: string;
-    audioFilter: string;
-    preset: string;
-    run: (input: { inputPath: string; outputPath: string; aspectRatio: string; audioFilter: string; preset: string }) => Promise<void>;
-  };
-};
-
-export type VideoGenerationPayload = {
-  caption?: string;
-  script?: string;
-  persona?: unknown;
-  context?: string;
-  durationSec?: number;
-};
-
-export type VideoGenerationJobData = {
-  jobId?: string;
-  payload?: VideoGenerationPayload;
-};
-
-export type VideoGenerationResult = {
-  success: true;
-  comfyJobId: string;
-  caption: string;
-  script: string;
-  context?: string;
-  persona?: unknown;
-  durationSec: number;
-  videoKey?: string;
-  videoUrl?: string;
-};
-
-export type VideoGenerationJob = Job<VideoGenerationJobData, VideoGenerationResult, 'video-generation'>;
-
-const DEFAULT_POLL_INTERVAL_MS = 5000;
-const DEFAULT_MAX_ATTEMPTS = 120;
-
-function sleep(ms: number) {
-  return new Promise<void>((resolve) => setTimeout(resolve, ms));
-}
-
-function cloneWorkflowPayload(payload?: Record<string, unknown>) {
-  if (!payload) return undefined;
-  return JSON.parse(JSON.stringify(payload)) as Record<string, unknown>;
-}
-
-function attachPromptMetadata(
-  base: Record<string, unknown> | undefined,
-  metadata: Record<string, unknown>,
-  inputs: Record<string, unknown>
-) {
-  const prompt = base ? { ...base } : {};
-  const existingInputs = (prompt.inputs as Record<string, unknown> | undefined) ?? {};
-  prompt.inputs = { ...existingInputs, ...inputs };
-
-  const extraData = (prompt.extra_data as Record<string, unknown> | undefined) ?? {};
-  const existingMeta = (extraData.metadata as Record<string, unknown> | undefined) ?? {};
-  extraData.metadata = { ...existingMeta, ...metadata };
-  prompt.extra_data = extraData;
-
-  return prompt;
-}
-
-function extractVideoAsset(history: any): ComfyOutputAsset | null {
-  const outputs = history?.outputs;
-  if (!outputs || typeof outputs !== 'object') return null;
-
-  const outputArrays = Object.values(outputs).filter(Array.isArray) as ComfyOutputAsset[][];
-  for (const arr of outputArrays) {
-    for (const entry of arr) {
-      if (!entry || typeof entry !== 'object') continue;
-      if (entry.type === 'video' || entry.type === 'output' || entry.url || (entry.filename && entry.filename.endsWith('.mp4'))) {
-        return entry;
-      }
-    }
-  }
-  return null;
-}
-
-function buildAssetUrl(baseUrl: string, asset: ComfyOutputAsset): string {
-  if (asset.url) {
-    const trimmed = asset.url.trim();
-    if (/^https?:/i.test(trimmed)) return trimmed;
-    const base = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
-    return `${base}/${trimmed.replace(/^\//, '')}`;
-  }
-
-  const filename = asset.filename;
-  if (!filename) {
-    throw new Error('ComfyUI output is missing filename');
-  }
-  const subfolder = asset.subfolder ?? '';
-  const type = asset.type ?? 'output';
-  const url = new URL('/view', baseUrl);
-  url.searchParams.set('filename', filename);
-  url.searchParams.set('subfolder', subfolder);
-  url.searchParams.set('type', type);
-  return url.toString();
-}
-
-function parseHistoryState(history: any) {
-  if (!history || typeof history !== 'object') {
-    return { state: 'running' as const };
-  }
-
-  const status = history.status ?? history;
-  const statusText = typeof status?.status === 'string' ? status.status.toLowerCase() : undefined;
-  const completed = status?.completed === true || statusText === 'completed' || statusText === 'success';
-  const failed = statusText === 'error' || statusText === 'failed' || statusText === 'cancelled' || status?.failed === true;
-  const error = status?.error ?? status?.err ?? status?.message;
-
-  if (failed) {
-    return { state: 'failed' as const, error: typeof error === 'string' ? error : 'ComfyUI job failed' };
-  }
-
-  if (completed) {
-    return { state: 'succeeded' as const };
-  }
-
-  if (typeof error === 'string' && error.trim()) {
-    return { state: 'failed' as const, error };
-  }
-
-  return { state: 'running' as const };
-}
+export type { S3Helper } from './videoGeneration/types';
 
 export function createVideoGenerationProcessor(deps: VideoGenerationDependencies) {
+  const comfyClient = createComfyClient(deps.comfy);
+
   const processor: Processor<VideoGenerationJobData, VideoGenerationResult, 'video-generation'> = async function process(
     job: VideoGenerationJob
   ) {
-    const { logger, patchJobStatus, s3, comfy, ffmpeg } = deps;
+    const { logger, patchJobStatus, s3, ffmpeg } = deps;
 
     logger.info({ id: job.id, name: job.name, data: job.data }, 'Processing video-generation job');
 
@@ -209,9 +64,6 @@ export function createVideoGenerationProcessor(deps: VideoGenerationDependencies
       await patchJobStatus(jobId, { status: 'running' });
     }
 
-    const pollIntervalMs = comfy.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-    const maxPollAttempts = comfy.maxPollAttempts ?? DEFAULT_MAX_ATTEMPTS;
-    const fetchFn = comfy.fetch;
     const metadata = {
       jobId,
       queueJobId: job.id,
@@ -226,123 +78,26 @@ export function createVideoGenerationProcessor(deps: VideoGenerationDependencies
     let tempDir: string | undefined;
 
     try {
-      const promptPayload = attachPromptMetadata(
-        cloneWorkflowPayload(comfy.workflowPayload),
+      const comfyResult = await comfyClient.submitVideoJob({
         metadata,
-        {
+        inputs: {
           caption,
           script,
           persona,
           personaText,
           context,
           durationSec,
-        }
-      );
-
-      const requestBody = {
-        client_id: comfy.clientId,
-        prompt: promptPayload,
-      } as Record<string, unknown>;
-
-      logger.info({ jobId, comfyRequest: { clientId: comfy.clientId } }, 'Submitting ComfyUI prompt');
-
-      const res = await fetchFn(`${comfy.baseUrl.replace(/\/$/, '')}/prompt`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(requestBody),
+        },
+        logger,
       });
 
-      if (!res.ok) {
-        throw new Error(`ComfyUI prompt failed with status ${res.status}`);
-      }
-
-      let json: any = null;
-      try {
-        json = await res.json();
-      } catch {
-        json = null;
-      }
-
-      comfyJobId =
-        (json?.prompt_id as string | undefined) || (json?.id as string | undefined) || (json?.job_id as string | undefined);
-
-      if (!comfyJobId) {
-        throw new Error('ComfyUI prompt response missing job identifier');
-      }
-
-      logger.info({ jobId, comfyJobId }, 'ComfyUI prompt accepted');
-
-      let attempt = 0;
-      let finalHistory: any = null;
-
-      while (attempt < maxPollAttempts) {
-        attempt += 1;
-        const historyRes = await fetchFn(`${comfy.baseUrl.replace(/\/$/, '')}/history/${encodeURIComponent(comfyJobId)}`);
-        if (historyRes.status === 404) {
-          await sleep(pollIntervalMs);
-          continue;
-        }
-
-        if (!historyRes.ok) {
-          throw new Error(`ComfyUI history request failed with status ${historyRes.status}`);
-        }
-
-        let historyJson: any;
-        try {
-          historyJson = await historyRes.json();
-        } catch (err) {
-          logger.warn({ err }, 'Unable to parse ComfyUI history response');
-          await sleep(pollIntervalMs);
-          continue;
-        }
-
-        const historyEntry = historyJson?.[comfyJobId] ?? historyJson;
-        finalHistory = historyEntry;
-        const state = parseHistoryState(historyEntry);
-
-        logger.info({ jobId, comfyJobId, attempt, state: state.state }, 'Polled ComfyUI job');
-
-        if (state.state === 'failed') {
-          throw new Error(state.error || 'ComfyUI job failed');
-        }
-
-        if (state.state === 'succeeded') {
-          break;
-        }
-
-        await sleep(pollIntervalMs);
-      }
-
-      if (!finalHistory) {
-        throw new Error('Timed out waiting for ComfyUI job history');
-      }
-
-      const finalState = parseHistoryState(finalHistory);
-      if (finalState.state !== 'succeeded') {
-        throw new Error('ComfyUI job did not complete successfully');
-      }
-
-      const asset = extractVideoAsset(finalHistory);
-      if (!asset) {
-        throw new Error('ComfyUI history did not contain a video output');
-      }
-
-      const assetUrl = buildAssetUrl(comfy.baseUrl, asset);
-      logger.info({ jobId, comfyJobId, assetUrl }, 'Downloading ComfyUI video output');
-
-      const downloadRes = await fetchFn(assetUrl);
-      if (!downloadRes.ok) {
-        throw new Error(`Failed to download ComfyUI output (${downloadRes.status})`);
-      }
-
-      const arrayBuffer = await downloadRes.arrayBuffer();
-      const buffer = Buffer.from(arrayBuffer);
+      comfyJobId = comfyResult.comfyJobId;
 
       tempDir = await mkdtemp(path.join(tmpdir(), 'video-generation-'));
       const rawPath = path.join(tempDir, 'raw.mp4');
       const processedPath = path.join(tempDir, 'processed.mp4');
 
-      await writeFile(rawPath, buffer);
+      await writeFile(rawPath, comfyResult.buffer);
 
       await ffmpeg.run({
         inputPath: rawPath,

--- a/apps/worker/src/processors/videoGeneration/comfyClient.ts
+++ b/apps/worker/src/processors/videoGeneration/comfyClient.ts
@@ -1,0 +1,257 @@
+import type { Logger } from 'pino';
+
+import type { FetchLike } from './types';
+
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+const DEFAULT_MAX_ATTEMPTS = 120;
+
+export type ComfyClientConfig = {
+  baseUrl: string;
+  clientId: string;
+  fetch: FetchLike;
+  workflowPayload?: Record<string, unknown>;
+  pollIntervalMs?: number;
+  maxPollAttempts?: number;
+};
+
+export type SubmitVideoJobOptions = {
+  metadata: Record<string, unknown>;
+  inputs: Record<string, unknown>;
+  logger?: Pick<Logger, 'info' | 'warn' | 'error'>;
+};
+
+export type SubmitVideoJobResult = {
+  comfyJobId: string;
+  assetUrl: string;
+  buffer: Buffer;
+};
+
+type ComfyOutputAsset = {
+  filename?: string;
+  subfolder?: string;
+  type?: string;
+  url?: string;
+};
+
+type HistoryState =
+  | { state: 'running' }
+  | { state: 'succeeded' }
+  | { state: 'failed'; error?: string };
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+function cloneWorkflowPayload(payload?: Record<string, unknown>) {
+  if (!payload) return undefined;
+  return JSON.parse(JSON.stringify(payload)) as Record<string, unknown>;
+}
+
+function attachPromptMetadata(
+  base: Record<string, unknown> | undefined,
+  metadata: Record<string, unknown>,
+  inputs: Record<string, unknown>
+) {
+  const prompt = base ? { ...base } : {};
+  const existingInputs = (prompt.inputs as Record<string, unknown> | undefined) ?? {};
+  prompt.inputs = { ...existingInputs, ...inputs };
+
+  const extraData = (prompt.extra_data as Record<string, unknown> | undefined) ?? {};
+  const existingMeta = (extraData.metadata as Record<string, unknown> | undefined) ?? {};
+  extraData.metadata = { ...existingMeta, ...metadata };
+  prompt.extra_data = extraData;
+
+  return prompt;
+}
+
+function parseHistoryState(history: any): HistoryState {
+  if (!history || typeof history !== 'object') {
+    return { state: 'running' };
+  }
+
+  const status = history.status ?? history;
+  const statusText = typeof status?.status === 'string' ? status.status.toLowerCase() : undefined;
+  const completed = status?.completed === true || statusText === 'completed' || statusText === 'success';
+  const failed = statusText === 'error' || statusText === 'failed' || statusText === 'cancelled' || status?.failed === true;
+  const error = status?.error ?? status?.err ?? status?.message;
+
+  if (failed) {
+    return { state: 'failed', error: typeof error === 'string' ? error : 'ComfyUI job failed' };
+  }
+
+  if (completed) {
+    return { state: 'succeeded' };
+  }
+
+  if (typeof error === 'string' && error.trim()) {
+    return { state: 'failed', error };
+  }
+
+  return { state: 'running' };
+}
+
+function extractVideoAsset(history: any): ComfyOutputAsset | null {
+  const outputs = history?.outputs;
+  if (!outputs || typeof outputs !== 'object') return null;
+
+  const outputArrays = Object.values(outputs).filter(Array.isArray) as ComfyOutputAsset[][];
+  for (const arr of outputArrays) {
+    for (const entry of arr) {
+      if (!entry || typeof entry !== 'object') continue;
+      if (entry.type === 'video' || entry.type === 'output' || entry.url || (entry.filename && entry.filename.endsWith('.mp4'))) {
+        return entry;
+      }
+    }
+  }
+  return null;
+}
+
+function buildAssetUrl(baseUrl: string, asset: ComfyOutputAsset): string {
+  if (asset.url) {
+    const trimmed = asset.url.trim();
+    if (/^https?:/i.test(trimmed)) return trimmed;
+    const base = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    return `${base}/${trimmed.replace(/^\//, '')}`;
+  }
+
+  const filename = asset.filename;
+  if (!filename) {
+    throw new Error('ComfyUI output is missing filename');
+  }
+  const subfolder = asset.subfolder ?? '';
+  const type = asset.type ?? 'output';
+  const url = new URL('/view', baseUrl);
+  url.searchParams.set('filename', filename);
+  url.searchParams.set('subfolder', subfolder);
+  url.searchParams.set('type', type);
+  return url.toString();
+}
+
+async function pollForCompletion(
+  config: ComfyClientConfig,
+  comfyJobId: string,
+  logger?: Pick<Logger, 'info' | 'warn' | 'error'>
+) {
+  const pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const maxPollAttempts = config.maxPollAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  let attempt = 0;
+  let finalHistory: any = null;
+
+  while (attempt < maxPollAttempts) {
+    attempt += 1;
+    const historyRes = await config.fetch(`${config.baseUrl.replace(/\/$/, '')}/history/${encodeURIComponent(comfyJobId)}`);
+    if (historyRes.status === 404) {
+      await sleep(pollIntervalMs);
+      continue;
+    }
+
+    if (!historyRes.ok) {
+      throw new Error(`ComfyUI history request failed with status ${historyRes.status}`);
+    }
+
+    let historyJson: any;
+    try {
+      historyJson = await historyRes.json();
+    } catch (err) {
+      logger?.warn({ err }, 'Unable to parse ComfyUI history response');
+      await sleep(pollIntervalMs);
+      continue;
+    }
+
+    const historyEntry = historyJson?.[comfyJobId] ?? historyJson;
+    finalHistory = historyEntry;
+    const state = parseHistoryState(historyEntry);
+
+    logger?.info({ comfyJobId, attempt, state: state.state }, 'Polled ComfyUI job');
+
+    if (state.state === 'failed') {
+      throw new Error(state.error || 'ComfyUI job failed');
+    }
+
+    if (state.state === 'succeeded') {
+      break;
+    }
+
+    await sleep(pollIntervalMs);
+  }
+
+  if (!finalHistory) {
+    throw new Error('Timed out waiting for ComfyUI job history');
+  }
+
+  const finalState = parseHistoryState(finalHistory);
+  if (finalState.state !== 'succeeded') {
+    throw new Error('ComfyUI job did not complete successfully');
+  }
+
+  const asset = extractVideoAsset(finalHistory);
+  if (!asset) {
+    throw new Error('ComfyUI history did not contain a video output');
+  }
+
+  const assetUrl = buildAssetUrl(config.baseUrl, asset);
+  return { assetUrl };
+}
+
+export function createComfyClient(config: ComfyClientConfig) {
+  return {
+    async submitVideoJob({ metadata, inputs, logger }: SubmitVideoJobOptions): Promise<SubmitVideoJobResult> {
+      const promptPayload = attachPromptMetadata(cloneWorkflowPayload(config.workflowPayload), metadata, inputs);
+
+      const requestBody = {
+        client_id: config.clientId,
+        prompt: promptPayload,
+      } as Record<string, unknown>;
+
+      logger?.info({ comfyRequest: { clientId: config.clientId } }, 'Submitting ComfyUI prompt');
+
+      const res = await config.fetch(`${config.baseUrl.replace(/\/$/, '')}/prompt`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!res.ok) {
+        throw new Error(`ComfyUI prompt failed with status ${res.status}`);
+      }
+
+      let json: any = null;
+      try {
+        json = await res.json();
+      } catch {
+        json = null;
+      }
+
+      const comfyJobId =
+        (json?.prompt_id as string | undefined) || (json?.id as string | undefined) || (json?.job_id as string | undefined);
+
+      if (!comfyJobId) {
+        throw new Error('ComfyUI prompt response missing job identifier');
+      }
+
+      logger?.info({ comfyJobId }, 'ComfyUI prompt accepted');
+
+      const { assetUrl } = await pollForCompletion(config, comfyJobId, logger);
+
+      logger?.info({ comfyJobId, assetUrl }, 'Downloading ComfyUI video output');
+      const downloadRes = await config.fetch(assetUrl);
+      if (!downloadRes.ok) {
+        throw new Error(`Failed to download ComfyUI output (${downloadRes.status})`);
+      }
+
+      const arrayBuffer = await downloadRes.arrayBuffer();
+      const buffer = Buffer.from(arrayBuffer);
+
+      return { comfyJobId, assetUrl, buffer };
+    },
+  };
+}
+
+export const __testUtils = {
+  sleep,
+  cloneWorkflowPayload,
+  attachPromptMetadata,
+  parseHistoryState,
+  extractVideoAsset,
+  buildAssetUrl,
+};

--- a/apps/worker/src/processors/videoGeneration/types.ts
+++ b/apps/worker/src/processors/videoGeneration/types.ts
@@ -1,0 +1,69 @@
+import type { Job } from 'bullmq';
+import type { Logger } from 'pino';
+import type { S3Client } from '@aws-sdk/client-s3';
+
+import type { PatchJobStatus } from '../contentGeneration';
+
+export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+export type S3ClientInfo = { client: S3Client; bucket: string };
+
+export type S3Helper = {
+  getClient: (logger?: Pick<Logger, 'info' | 'warn' | 'error'>) => S3ClientInfo | null;
+  putBinaryObject: (
+    client: S3Client,
+    bucket: string,
+    key: string,
+    body: NodeJS.ReadableStream | Uint8Array | Buffer,
+    contentType?: string
+  ) => Promise<void>;
+  putTextObject: (client: S3Client, bucket: string, key: string, content: string) => Promise<void>;
+  getSignedGetUrl: (client: S3Client, bucket: string, key: string, expiresInSeconds?: number) => Promise<string>;
+};
+
+export type VideoGenerationDependencies = {
+  logger: Pick<Logger, 'info' | 'warn' | 'error'>;
+  patchJobStatus: PatchJobStatus;
+  s3: S3Helper;
+  comfy: {
+    baseUrl: string;
+    clientId: string;
+    fetch: FetchLike;
+    workflowPayload?: Record<string, unknown>;
+    pollIntervalMs?: number;
+    maxPollAttempts?: number;
+  };
+  ffmpeg: {
+    aspectRatio: string;
+    audioFilter: string;
+    preset: string;
+    run: (input: { inputPath: string; outputPath: string; aspectRatio: string; audioFilter: string; preset: string }) => Promise<void>;
+  };
+};
+
+export type VideoGenerationPayload = {
+  caption?: string;
+  script?: string;
+  persona?: unknown;
+  context?: string;
+  durationSec?: number;
+};
+
+export type VideoGenerationJobData = {
+  jobId?: string;
+  payload?: VideoGenerationPayload;
+};
+
+export type VideoGenerationResult = {
+  success: true;
+  comfyJobId: string;
+  caption: string;
+  script: string;
+  context?: string;
+  persona?: unknown;
+  durationSec: number;
+  videoKey?: string;
+  videoUrl?: string;
+};
+
+export type VideoGenerationJob = Job<VideoGenerationJobData, VideoGenerationResult, 'video-generation'>;


### PR DESCRIPTION
## Summary
- extract video generation types and shared helper definitions into a dedicated module
- encapsulate ComfyUI workflow submission and polling in a reusable comfy client
- update the video generation processor to use the comfy client and re-export shared types

## Testing
- pnpm --filter @influencerai/worker test

------
https://chatgpt.com/codex/tasks/task_e_68e8020ebe6c8320b4ea83589738dd48