### PR TITLE
feat(web): add content plan wizard

### DIFF
--- a/apps/web/src/__tests__/content-plan-prompt.test.ts
+++ b/apps/web/src/__tests__/content-plan-prompt.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { buildContentPlanPrompt } from "../lib/content-plans/prompt";
+
+const baseInput = {
+  persona: {
+    name: "Social Media Manager",
+    audience: "Marketing Team",
+    context: "Gestisce i contenuti per un brand tech",
+  },
+  theme: "Lancio prodotto Q1",
+  tone: "Ispirazionale",
+  callToAction: "Scarica la guida completa",
+  postCount: 3,
+};
+
+describe("buildContentPlanPrompt", () => {
+  it("produces a stable prompt for the content plan generation", () => {
+    expect(buildContentPlanPrompt(baseInput)).toMatchInlineSnapshot(`
+"Genera un piano editoriale per social media.
+
+[Persona]
+Nome: Social Media Manager
+Audience: Marketing Team
+Contesto: Gestisce i contenuti per un brand tech
+
+[Obiettivo]
+Tema principale: Lancio prodotto Q1
+Tono desiderato: Ispirazionale
+Call to action: Scarica la guida completa
+Numero di post richiesti: 3
+
+[Fornisci]
+- Un titolo sintetico per ciascun post
+- Una descrizione di massimo 280 caratteri
+- Una call to action coerente
+- Un suggerimento di formato (reel, carosello, stories)
+
+Restituisci i risultati come array JSON con chiavi id, title, summary, callToAction, formatSuggestion."
+`);
+  });
+});

--- a/apps/web/src/__tests__/content-plan-wizard.test.tsx
+++ b/apps/web/src/__tests__/content-plan-wizard.test.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ContentPlanWizard } from "../components/content-plans/ContentPlanWizard";
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient();
+
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  );
+}
+
+describe("ContentPlanWizard", () => {
+  const API_BASE_URL = "https://api.example.com";
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.NEXT_PUBLIC_API_BASE_URL = API_BASE_URL;
+  });
+
+  it("guides the user through persona and theme steps before showing a preview", async () => {
+    const user = userEvent.setup();
+
+    const fetchMock = vi.fn(async (input: RequestInfo, init?: RequestInit) => {
+      if (typeof input === "string" && input.endsWith("/content-plans")) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: "plan-123",
+            status: "DRAFT",
+            persona: {
+              name: "Social Media Manager",
+              audience: "Marketing Team",
+            },
+            prompt: "Generated prompt",
+            posts: [
+              { id: "post-1", title: "Post 1", summary: "Summary 1", callToAction: "CTA 1" },
+              { id: "post-2", title: "Post 2", summary: "Summary 2", callToAction: "CTA 2" },
+            ],
+          }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch call: ${input}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock as typeof fetch);
+
+    renderWithProviders(<ContentPlanWizard />);
+
+    await user.type(screen.getByLabelText(/^persona$/i), "Social Media Manager");
+    await user.type(screen.getByLabelText(/audience/i), "Marketing Team");
+    await user.type(
+      screen.getByLabelText(/contesto della persona/i),
+      "Gestisce i contenuti dei social media"
+    );
+
+    await user.click(screen.getByRole("button", { name: /prossimo/i }));
+
+    await user.type(screen.getByLabelText(/tema del piano/i), "Lancio prodotto");
+    await user.type(screen.getByLabelText(/tono/i), "Ispirazionale");
+    await user.clear(screen.getByLabelText(/numero di post/i));
+    await user.type(screen.getByLabelText(/numero di post/i), "3");
+    await user.type(screen.getByLabelText(/call to action/i), "Scarica ora");
+
+    await user.click(screen.getByRole("button", { name: /genera anteprima/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Post 1")).toBeInTheDocument();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${API_BASE_URL}/content-plans`);
+    expect(init?.method).toBe("POST");
+  });
+
+  it("allows regenerating the preview and approving the plan", async () => {
+    const user = userEvent.setup();
+
+    const responses = [
+      {
+        id: "plan-123",
+        status: "DRAFT",
+        persona: {
+          name: "Social Media Manager",
+          audience: "Marketing Team",
+        },
+        prompt: "Generated prompt",
+        posts: [
+          { id: "post-1", title: "Post 1", summary: "Summary 1", callToAction: "CTA 1" },
+        ],
+      },
+      {
+        id: "plan-123",
+        status: "DRAFT",
+        persona: {
+          name: "Social Media Manager",
+          audience: "Marketing Team",
+        },
+        prompt: "Generated prompt",
+        posts: [
+          { id: "post-1", title: "Post 1", summary: "Summary 1", callToAction: "CTA 1" },
+          { id: "post-2", title: "Post 2", summary: "Summary 2", callToAction: "CTA 2" },
+        ],
+      },
+      {
+        id: "plan-123",
+        status: "APPROVED",
+      },
+    ];
+
+    const fetchMock = vi.fn(async (input: RequestInfo, init?: RequestInit) => {
+      if (typeof input === "string" && input.endsWith("/content-plans")) {
+        return {
+          ok: true,
+          json: async () => responses.shift(),
+        } as Response;
+      }
+
+      if (typeof input === "string" && input.includes("/content-plans/plan-123/status")) {
+        return {
+          ok: true,
+          json: async () => responses.pop(),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch call: ${input}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock as typeof fetch);
+
+    renderWithProviders(<ContentPlanWizard />);
+
+    await user.type(screen.getByLabelText(/^persona$/i), "Social Media Manager");
+    await user.type(screen.getByLabelText(/audience/i), "Marketing Team");
+    await user.type(
+      screen.getByLabelText(/contesto della persona/i),
+      "Gestisce i contenuti dei social media"
+    );
+    await user.click(screen.getByRole("button", { name: /prossimo/i }));
+    await user.type(screen.getByLabelText(/tema del piano/i), "Lancio prodotto");
+    await user.type(screen.getByLabelText(/tono/i), "Ispirazionale");
+    await user.clear(screen.getByLabelText(/numero di post/i));
+    await user.type(screen.getByLabelText(/numero di post/i), "1");
+    await user.type(screen.getByLabelText(/call to action/i), "Scarica ora");
+    await user.click(screen.getByRole("button", { name: /genera anteprima/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Post 1")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /rigenera piano/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Post 2")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /approva piano/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${API_BASE_URL}/content-plans/plan-123/status`,
+        expect.objectContaining({
+          method: "PATCH",
+        })
+      );
+    });
+  });
+});

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -4,6 +4,7 @@ import { AppShell } from "@/components/layout/AppShell";
 
 const navItems = [
   { title: "Dashboard", href: "/dashboard" },
+  { title: "Content Plans", href: "/dashboard/content-plans" },
   { title: "Jobs", href: "/dashboard/jobs" },
   { title: "Queues", href: "/dashboard/queues" },
 ];

--- a/apps/web/src/app/dashboard/content-plans/page.tsx
+++ b/apps/web/src/app/dashboard/content-plans/page.tsx
@@ -1,0 +1,26 @@
+import { ContentPlanWizard } from "@/components/content-plans/ContentPlanWizard";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+export default function ContentPlansPage() {
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-4 border-b border-border/60 pb-6 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-2">
+          <Badge variant="brand" className="bg-brand-100 text-brand-700">
+            Content Planning
+          </Badge>
+          <h1 className="text-3xl font-semibold text-foreground">
+            Genera e approva il piano editoriale
+          </h1>
+          <p className="max-w-2xl text-sm text-muted-foreground">
+            Completa il wizard per creare un piano editoriale personalizzato per
+            la tua persona e gestisci l'approvazione del contenuto.
+          </p>
+        </div>
+        <Button variant="secondary">Scarica come CSV</Button>
+      </header>
+      <ContentPlanWizard />
+    </div>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import { ArrowUpRight, Sparkles } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { ModeToggle } from "../components/mode-toggle";

--- a/apps/web/src/components/content-plans/ContentPlanWizard.tsx
+++ b/apps/web/src/components/content-plans/ContentPlanWizard.tsx
@@ -1,0 +1,511 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  ContentPlan,
+  ContentPlanGenerateInput,
+  createContentPlan,
+  updateContentPlanStatus,
+} from "@/lib/content-plans";
+
+const personaSchema = z.object({
+  name: z.string().min(1, "La persona è obbligatoria"),
+  audience: z.string().min(1, "L'audience è obbligatoria"),
+  context: z.string().min(1, "Descrivi il contesto"),
+});
+
+const promptSchema = z.object({
+  theme: z.string().min(1, "Il tema è obbligatorio"),
+  tone: z.string().min(1, "Il tono è obbligatorio"),
+  callToAction: z.string().min(1, "Specifica una call to action"),
+  postCount: z
+    .number()
+    .int("Inserisci un numero intero")
+    .min(1, "Almeno un post")
+    .max(10, "Massimo 10 post"),
+});
+
+type PersonaFormState = z.infer<typeof personaSchema>;
+
+type PromptFormState = {
+  theme: string;
+  tone: string;
+  callToAction: string;
+  postCount: string;
+};
+
+type WizardStep = "persona" | "prompt" | "preview";
+
+type FieldErrors<TKeys extends string> = Partial<Record<TKeys, string>>;
+
+const initialPersonaState: PersonaFormState = {
+  name: "",
+  audience: "",
+  context: "",
+};
+
+const initialPromptState: PromptFormState = {
+  theme: "",
+  tone: "",
+  callToAction: "",
+  postCount: "3",
+};
+
+const STEPS: { id: WizardStep; label: string }[] = [
+  { id: "persona", label: "Persona" },
+  { id: "prompt", label: "Parametri" },
+  { id: "preview", label: "Anteprima" },
+];
+
+function mapZodErrors<TKeys extends string>(
+  errors: Record<string, string[] | undefined>
+): FieldErrors<TKeys> {
+  return Object.entries(errors).reduce<FieldErrors<TKeys>>(
+    (acc, [key, messages]) => {
+      if (messages && messages.length > 0) {
+        acc[key as TKeys] = messages[0];
+      }
+      return acc;
+    },
+    {}
+  );
+}
+
+export function ContentPlanWizard() {
+  const [step, setStep] = useState<WizardStep>("persona");
+  const [personaForm, setPersonaForm] = useState<PersonaFormState>(
+    initialPersonaState
+  );
+  const [promptForm, setPromptForm] = useState<PromptFormState>(
+    initialPromptState
+  );
+  const [personaErrors, setPersonaErrors] = useState<
+    FieldErrors<keyof PersonaFormState>
+  >({});
+  const [promptErrors, setPromptErrors] = useState<
+    FieldErrors<keyof PromptFormState>
+  >({});
+  const [plan, setPlan] = useState<ContentPlan | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const generateMutation = useMutation({
+    mutationFn: createContentPlan,
+    onSuccess: (nextPlan) => {
+      setPlan(nextPlan);
+      setStep("preview");
+      setFeedback("Piano generato correttamente.");
+    },
+    onError: (error: unknown) => {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Impossibile generare il piano. Riprova.";
+      setFeedback(message);
+    },
+  });
+
+  const statusMutation = useMutation({
+    mutationFn: updateContentPlanStatus,
+    onSuccess: (updatedPlan) => {
+      setPlan((current) => {
+        if (!current) {
+          return updatedPlan;
+        }
+        return { ...current, status: updatedPlan.status };
+      });
+      setFeedback("Stato del piano aggiornato.");
+    },
+    onError: (error: unknown) => {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Aggiornamento stato non riuscito.";
+      setFeedback(message);
+    },
+  });
+
+  const isLoadingPlan = generateMutation.isPending;
+  const isUpdatingStatus = statusMutation.isPending;
+
+  const parsedPromptInput = useMemo(() => {
+    const parsedPostCount = Number.parseInt(promptForm.postCount, 10);
+    return {
+      theme: promptForm.theme,
+      tone: promptForm.tone,
+      callToAction: promptForm.callToAction,
+      postCount: Number.isNaN(parsedPostCount) ? 0 : parsedPostCount,
+    };
+  }, [promptForm]);
+
+  function handlePersonaSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const result = personaSchema.safeParse(personaForm);
+
+    if (!result.success) {
+      setPersonaErrors(mapZodErrors(result.error.flatten().fieldErrors));
+      return;
+    }
+
+    setPersonaErrors({});
+    setPersonaForm(result.data);
+    setStep("prompt");
+    setFeedback(null);
+  }
+
+  function handlePromptSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const result = promptSchema.safeParse(parsedPromptInput);
+
+    if (!result.success) {
+      setPromptErrors(mapZodErrors(result.error.flatten().fieldErrors));
+      return;
+    }
+
+    setPromptErrors({});
+
+    const payload: ContentPlanGenerateInput = {
+      persona: personaForm,
+      ...result.data,
+    };
+
+    setFeedback("Generazione del piano in corso...");
+    generateMutation.mutate(payload);
+  }
+
+  function handleRegenerate() {
+    const result = promptSchema.safeParse(parsedPromptInput);
+    if (!result.success) {
+      setPromptErrors(mapZodErrors(result.error.flatten().fieldErrors));
+      setStep("prompt");
+      return;
+    }
+
+    const payload: ContentPlanGenerateInput = {
+      persona: personaForm,
+      ...result.data,
+    };
+
+    setFeedback("Rigenerazione del piano in corso...");
+    generateMutation.mutate(payload);
+  }
+
+  function handleStatusChange(status: "APPROVED" | "REJECTED") {
+    if (!plan) {
+      return;
+    }
+
+    setFeedback("Aggiornamento stato in corso...");
+    statusMutation.mutate({ planId: plan.id, status });
+  }
+
+  return (
+    <div className="space-y-6">
+      <ol className="flex flex-wrap items-center gap-2 text-sm font-medium text-muted-foreground">
+        {STEPS.map((wizardStep, index) => {
+          const isActive = wizardStep.id === step;
+          const isCompleted = STEPS.findIndex(({ id }) => id === step) > index;
+          return (
+            <li
+              key={wizardStep.id}
+              className="flex items-center gap-2"
+              aria-current={isActive ? "step" : undefined}
+            >
+              <span
+                className={`flex h-8 w-8 items-center justify-center rounded-full border text-xs ${
+                  isActive
+                    ? "border-brand-500 bg-brand-100 text-brand-700"
+                    : isCompleted
+                      ? "border-brand-200 bg-brand-50 text-brand-600"
+                      : "border-border"
+                }`}
+              >
+                {index + 1}
+              </span>
+              <span className={isActive ? "text-foreground" : undefined}>
+                {wizardStep.label}
+              </span>
+              {index < STEPS.length - 1 ? <span className="text-xs">›</span> : null}
+            </li>
+          );
+        })}
+      </ol>
+
+      {step === "persona" ? (
+        <Card>
+          <form onSubmit={handlePersonaSubmit} className="space-y-4">
+            <CardHeader>
+              <CardTitle>Definisci la persona</CardTitle>
+              <CardDescription>
+                Identifica la figura a cui è destinato il piano editoriale e il
+                suo contesto.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="persona-name">Persona</Label>
+                <Input
+                  id="persona-name"
+                  value={personaForm.name}
+                  onChange={(event) =>
+                    setPersonaForm((current) => ({
+                      ...current,
+                      name: event.target.value,
+                    }))
+                  }
+                />
+                {personaErrors.name ? (
+                  <p className="text-sm text-destructive">{personaErrors.name}</p>
+                ) : null}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="persona-audience">Audience</Label>
+                <Input
+                  id="persona-audience"
+                  value={personaForm.audience}
+                  onChange={(event) =>
+                    setPersonaForm((current) => ({
+                      ...current,
+                      audience: event.target.value,
+                    }))
+                  }
+                />
+                {personaErrors.audience ? (
+                  <p className="text-sm text-destructive">
+                    {personaErrors.audience}
+                  </p>
+                ) : null}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="persona-context">Contesto della persona</Label>
+                <textarea
+                  id="persona-context"
+                  className="min-h-[120px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  value={personaForm.context}
+                  onChange={(event) =>
+                    setPersonaForm((current) => ({
+                      ...current,
+                      context: event.target.value,
+                    }))
+                  }
+                />
+                {personaErrors.context ? (
+                  <p className="text-sm text-destructive">
+                    {personaErrors.context}
+                  </p>
+                ) : null}
+              </div>
+            </CardContent>
+            <div className="flex justify-end gap-2 border-t border-border/60 px-6 py-4">
+              <Button type="submit">Prossimo</Button>
+            </div>
+          </form>
+        </Card>
+      ) : null}
+
+      {step === "prompt" ? (
+        <Card>
+          <form onSubmit={handlePromptSubmit} className="space-y-4">
+            <CardHeader>
+              <CardTitle>Parametri del piano</CardTitle>
+              <CardDescription>
+                Definisci il tema, il tono e il numero di post da generare.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="plan-theme">Tema del piano</Label>
+                <Input
+                  id="plan-theme"
+                  value={promptForm.theme}
+                  onChange={(event) =>
+                    setPromptForm((current) => ({
+                      ...current,
+                      theme: event.target.value,
+                    }))
+                  }
+                />
+                {promptErrors.theme ? (
+                  <p className="text-sm text-destructive">{promptErrors.theme}</p>
+                ) : null}
+              </div>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="plan-tone">Tono</Label>
+                  <Input
+                    id="plan-tone"
+                    value={promptForm.tone}
+                    onChange={(event) =>
+                      setPromptForm((current) => ({
+                        ...current,
+                        tone: event.target.value,
+                      }))
+                    }
+                  />
+                  {promptErrors.tone ? (
+                    <p className="text-sm text-destructive">{promptErrors.tone}</p>
+                  ) : null}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="plan-post-count">Numero di post</Label>
+                  <Input
+                    id="plan-post-count"
+                    inputMode="numeric"
+                    value={promptForm.postCount}
+                    onChange={(event) =>
+                      setPromptForm((current) => ({
+                        ...current,
+                        postCount: event.target.value,
+                      }))
+                    }
+                  />
+                  {promptErrors.postCount ? (
+                    <p className="text-sm text-destructive">
+                      {promptErrors.postCount}
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="plan-cta">Call to action</Label>
+                <Input
+                  id="plan-cta"
+                  value={promptForm.callToAction}
+                  onChange={(event) =>
+                    setPromptForm((current) => ({
+                      ...current,
+                      callToAction: event.target.value,
+                    }))
+                  }
+                />
+                {promptErrors.callToAction ? (
+                  <p className="text-sm text-destructive">
+                    {promptErrors.callToAction}
+                  </p>
+                ) : null}
+              </div>
+            </CardContent>
+            <div className="flex justify-between gap-2 border-t border-border/60 px-6 py-4">
+              <Button variant="outline" type="button" onClick={() => setStep("persona")}>
+                Indietro
+              </Button>
+              <Button type="submit" disabled={isLoadingPlan}>
+                {isLoadingPlan ? "Generazione..." : "Genera anteprima"}
+              </Button>
+            </div>
+          </form>
+        </Card>
+      ) : null}
+
+      {step === "preview" ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Anteprima contenuti</CardTitle>
+            <CardDescription>
+              Rivedi i post generati prima di approvare o richiedere una nuova
+              iterazione.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {isLoadingPlan ? (
+              <p role="status" className="text-sm text-muted-foreground">
+                Generazione del piano in corso...
+              </p>
+            ) : null}
+            {!isLoadingPlan && plan ? (
+              <div className="space-y-4">
+                <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                  <span className="font-medium text-foreground">Stato:</span>
+                  <span className="rounded-full bg-muted px-3 py-1 capitalize">
+                    {plan.status.toLowerCase()}
+                  </span>
+                </div>
+                <div className="grid gap-4 md:grid-cols-2">
+                  {plan.posts.map((post) => (
+                    <article
+                      key={post.id}
+                      className="rounded-lg border border-border/60 bg-card p-4 shadow-sm"
+                    >
+                      <h3 className="text-lg font-semibold text-foreground">
+                        {post.title}
+                      </h3>
+                      <p className="text-sm text-muted-foreground">
+                        {post.summary}
+                      </p>
+                      <div className="mt-4 text-xs uppercase text-muted-foreground">
+                        Call to action
+                      </div>
+                      <p className="text-sm text-foreground">{post.callToAction}</p>
+                      {post.formatSuggestion ? (
+                        <p className="mt-2 text-xs text-muted-foreground">
+                          Formato suggerito: {post.formatSuggestion}
+                        </p>
+                      ) : null}
+                    </article>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+            {!isLoadingPlan && !plan ? (
+              <p className="text-sm text-muted-foreground">
+                Compila i passaggi precedenti per generare un piano editoriale.
+              </p>
+            ) : null}
+          </CardContent>
+          <div className="flex flex-col gap-2 border-t border-border/60 p-6 md:flex-row md:items-center md:justify-between">
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                type="button"
+                onClick={() => setStep("prompt")}
+              >
+                Modifica parametri
+              </Button>
+              <Button
+                variant="secondary"
+                type="button"
+                onClick={handleRegenerate}
+                disabled={isLoadingPlan}
+              >
+                {isLoadingPlan ? "Rigenerazione..." : "Rigenera piano"}
+              </Button>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="destructive"
+                type="button"
+                onClick={() => handleStatusChange("REJECTED")}
+                disabled={isUpdatingStatus}
+              >
+                {isUpdatingStatus ? "Aggiornamento..." : "Rifiuta piano"}
+              </Button>
+              <Button
+                type="button"
+                onClick={() => handleStatusChange("APPROVED")}
+                disabled={isUpdatingStatus}
+              >
+                {isUpdatingStatus ? "Aggiornamento..." : "Approva piano"}
+              </Button>
+            </div>
+          </div>
+        </Card>
+      ) : null}
+
+      <p aria-live="polite" className="text-sm text-muted-foreground">
+        {feedback}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/mode-toggle.tsx
+++ b/apps/web/src/components/mode-toggle.tsx
@@ -1,13 +1,13 @@
 "use client";
 
+import * as React from "react";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
 
 export function ModeToggle() {
   const { theme, setTheme, resolvedTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
+  const [mounted, setMounted] = React.useState(false);
 
-  useEffect(() => {
+  React.useEffect(() => {
     setMounted(true);
   }, []);
 

--- a/apps/web/src/components/ui/label.tsx
+++ b/apps/web/src/components/ui/label.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
-import * as LabelPrimitive from "@radix-ui/react-label";
 
 import { cn } from "@/lib/utils";
 
 const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+  HTMLLabelElement,
+  React.LabelHTMLAttributes<HTMLLabelElement>
 >(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root
+  <label
     ref={ref}
     className={cn(
       "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
@@ -16,6 +15,6 @@ const Label = React.forwardRef<
     {...props}
   />
 ));
-Label.displayName = LabelPrimitive.Root.displayName;
+Label.displayName = "Label";
 
 export { Label };

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,5 +1,3 @@
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
-
 type ApiRequestInit = globalThis.RequestInit;
 
 export class ApiError extends Error {
@@ -12,12 +10,10 @@ export class ApiError extends Error {
   }
 }
 
-export async function apiGet<T>(path: string, init?: ApiRequestInit): Promise<T> {
-  if (!API_BASE_URL) {
-    throw new ApiError("Missing NEXT_PUBLIC_API_BASE_URL environment variable");
-  }
+async function apiRequest<T>(path: string, init?: ApiRequestInit): Promise<T> {
+  const baseUrl = getApiBaseUrl();
 
-  const response = await fetch(`${API_BASE_URL}${path}`, {
+  const response = await fetch(`${baseUrl}${path}`, {
     cache: "no-store",
     ...init,
   });
@@ -26,5 +22,55 @@ export async function apiGet<T>(path: string, init?: ApiRequestInit): Promise<T>
     throw new ApiError(`Request failed with status ${response.status}`, response.status);
   }
 
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
   return response.json() as Promise<T>;
+}
+
+export async function apiGet<T>(path: string, init?: ApiRequestInit): Promise<T> {
+  return apiRequest<T>(path, init);
+}
+
+function getApiBaseUrl(): string {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  if (!baseUrl) {
+    throw new ApiError("Missing NEXT_PUBLIC_API_BASE_URL environment variable");
+  }
+
+  return baseUrl;
+}
+
+export async function apiPost<TBody, TResponse>(
+  path: string,
+  body: TBody,
+  init?: ApiRequestInit
+): Promise<TResponse> {
+  const headers = new Headers(init?.headers ?? {});
+  headers.set("Content-Type", "application/json");
+
+  return apiRequest<TResponse>(path, {
+    ...init,
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+export async function apiPatch<TBody, TResponse>(
+  path: string,
+  body: TBody,
+  init?: ApiRequestInit
+): Promise<TResponse> {
+  const headers = new Headers(init?.headers ?? {});
+  headers.set("Content-Type", "application/json");
+
+  return apiRequest<TResponse>(path, {
+    ...init,
+    method: "PATCH",
+    headers,
+    body: JSON.stringify(body),
+  });
 }

--- a/apps/web/src/lib/content-plans/api.ts
+++ b/apps/web/src/lib/content-plans/api.ts
@@ -1,0 +1,37 @@
+import { apiPatch, apiPost } from "../api";
+import { buildContentPlanPrompt } from "./prompt";
+import {
+  ContentPlan,
+  ContentPlanGenerateInput,
+  UpdateContentPlanStatusInput,
+} from "./types";
+
+type CreateContentPlanRequest = ContentPlanGenerateInput & { prompt: string };
+
+type UpdateContentPlanStatusRequest = {
+  status: UpdateContentPlanStatusInput["status"];
+};
+
+export async function createContentPlan(
+  input: ContentPlanGenerateInput
+): Promise<ContentPlan> {
+  const payload: CreateContentPlanRequest = {
+    ...input,
+    prompt: buildContentPlanPrompt(input),
+  };
+
+  return apiPost<CreateContentPlanRequest, ContentPlan>(
+    "/content-plans",
+    payload
+  );
+}
+
+export async function updateContentPlanStatus({
+  planId,
+  status,
+}: UpdateContentPlanStatusInput): Promise<ContentPlan> {
+  return apiPatch<UpdateContentPlanStatusRequest, ContentPlan>(
+    `/content-plans/${planId}/status`,
+    { status }
+  );
+}

--- a/apps/web/src/lib/content-plans/index.ts
+++ b/apps/web/src/lib/content-plans/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./prompt";
+export * from "./api";

--- a/apps/web/src/lib/content-plans/prompt.ts
+++ b/apps/web/src/lib/content-plans/prompt.ts
@@ -1,0 +1,32 @@
+import { ContentPlanGenerateInput } from "./types";
+
+export function buildContentPlanPrompt({
+  persona,
+  theme,
+  tone,
+  callToAction,
+  postCount,
+}: ContentPlanGenerateInput): string {
+  return [
+    "Genera un piano editoriale per social media.",
+    "",
+    "[Persona]",
+    `Nome: ${persona.name}`,
+    `Audience: ${persona.audience}`,
+    `Contesto: ${persona.context}`,
+    "",
+    "[Obiettivo]",
+    `Tema principale: ${theme}`,
+    `Tono desiderato: ${tone}`,
+    `Call to action: ${callToAction}`,
+    `Numero di post richiesti: ${postCount}`,
+    "",
+    "[Fornisci]",
+    "- Un titolo sintetico per ciascun post",
+    "- Una descrizione di massimo 280 caratteri",
+    "- Una call to action coerente",
+    "- Un suggerimento di formato (reel, carosello, stories)",
+    "",
+    "Restituisci i risultati come array JSON con chiavi id, title, summary, callToAction, formatSuggestion.",
+  ].join("\n");
+}

--- a/apps/web/src/lib/content-plans/types.ts
+++ b/apps/web/src/lib/content-plans/types.ts
@@ -1,0 +1,36 @@
+export type ContentPlanStatus = "DRAFT" | "APPROVED" | "REJECTED";
+
+export type ContentPlanPersona = {
+  name: string;
+  audience: string;
+  context: string;
+};
+
+export type ContentPlanPost = {
+  id: string;
+  title: string;
+  summary: string;
+  callToAction: string;
+  formatSuggestion?: string;
+};
+
+export type ContentPlan = {
+  id: string;
+  status: ContentPlanStatus;
+  persona: Pick<ContentPlanPersona, "name" | "audience">;
+  prompt: string;
+  posts: ContentPlanPost[];
+};
+
+export type ContentPlanGenerateInput = {
+  persona: ContentPlanPersona;
+  theme: string;
+  tone: string;
+  callToAction: string;
+  postCount: number;
+};
+
+export type UpdateContentPlanStatusInput = {
+  planId: string;
+  status: Exclude<ContentPlanStatus, "DRAFT">;
+};

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,9 +1,19 @@
-﻿import { defineConfig } from 'vitest/config';
+import path from "node:path";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  esbuild: {
+    loader: "tsx",
+    jsx: "automatic",
+  },
   test: {
-    environment: 'jsdom',
-    setupFiles: ['./src/setupTests.ts'],
+    environment: "jsdom",
+    setupFiles: ["./src/setupTests.ts"],
     globals: true,
   },
 });


### PR DESCRIPTION
## Summary
- add a multi-step content plan wizard page with approval controls in the web dashboard
- introduce content plan domain helpers, API utilities, and validation-driven UI
- expand automated coverage for the wizard flow and prompt generation while configuring Vitest aliases

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e80765e8b483208914754c8a3b60af