### PR TITLE
chore: mark web-05 DoD as completed

### DIFF
--- a/backlog/issues.yaml
+++ b/backlog/issues.yaml
@@ -644,13 +644,13 @@ issues:
 
     ### DoD
 
-    - [ ] Wizard multi-step (persona, tema, parametri prompt) che chiama /content-plans.
+    - [x] Wizard multi-step (persona, tema, parametri prompt) che chiama /content-plans.
 
-    - [ ] Preview dei post generati con possibilità di rigenerare.
+    - [x] Preview dei post generati con possibilità di rigenerare.
 
-    - [ ] Stato "Approved"/"Rejected" sincronizzato con l''API.
+    - [x] Stato "Approved"/"Rejected" sincronizzato con l''API.
 
-    - [ ] Test componenti principali e snapshot prompt.
+    - [x] Test componenti principali e snapshot prompt.
 
 
     ### Dipendenze


### PR DESCRIPTION
## Summary
- mark all WEB-05 acceptance criteria as completed in `backlog/issues.yaml` after verifying the wizard implementation

## Testing
- pnpm --filter @influencerai/web test

------
https://chatgpt.com/codex/tasks/task_e_68e8a0e4eb4083208fbdae3adfd112e1