### PR TITLE
feat(worker): harden content-generation processor

### DIFF
--- a/backlog/issues.yaml
+++ b/backlog/issues.yaml
@@ -374,13 +374,13 @@ issues:
 
     ### DoD
 
-    - [ ] Implementato processor che richiama OpenRouter usando prompts.
+    - [x] Implementato processor che richiama OpenRouter usando prompts.
 
-    - [ ] Salvataggio output testuale su S3/Asset e collegamento al job.
+    - [x] Salvataggio output testuale su S3/Asset e collegamento al job.
 
-    - [ ] Gestione errori con retry e logging strutturato.
+    - [x] Gestione errori con retry e logging strutturato.
 
-    - [ ] Test unit/integration con mock OpenRouter.
+    - [x] Test unit/integration con mock OpenRouter.
 
 
     ### Dipendenze


### PR DESCRIPTION
## Summary
- ensure the content-generation processor rejects empty caption or script responses and reuses trimmed text for downstream actions
- extend unit coverage to verify prompt construction, failure propagation, and asset handling
- mark WORK-02 definition of done items as completed in the backlog tracker

## Testing
- pnpm test -- contentGeneration


------
https://chatgpt.com/codex/tasks/task_e_68e8a23b3b4c8320a591ae2e5a78c47a