### PR TITLE
Use sanitized caption for video script prompt

### DIFF
--- a/apps/worker/src/processors/contentGeneration.test.ts
+++ b/apps/worker/src/processors/contentGeneration.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createContentGenerationProcessor } from './contentGeneration';
 
 const noopLogger = {
@@ -16,6 +16,8 @@ describe('content generation processor', () => {
     const patchCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
     const uploadCalls: Array<{ jobIdentifier: string; caption: string; script: string }> = [];
     let childJobPayload: Record<string, unknown> | undefined;
+
+    const videoScriptPrompt = vi.fn((caption, duration) => `SCRIPT_PROMPT:${caption}:${duration}`);
 
     const processor = createContentGenerationProcessor({
       logger: noopLogger,
@@ -37,7 +39,7 @@ describe('content generation processor', () => {
       },
       prompts: {
         imageCaptionPrompt: (value) => `CAPTION_PROMPT:${value}`,
-        videoScriptPrompt: (caption, duration) => `SCRIPT_PROMPT:${caption}:${duration}`,
+        videoScriptPrompt,
       },
     });
 
@@ -90,6 +92,8 @@ describe('content generation processor', () => {
         costTok: 30,
       },
     });
+
+    expect(videoScriptPrompt).toHaveBeenCalledWith('caption one', 45);
   });
 
   it('reports failure to API when OpenRouter fails', async () => {

--- a/apps/worker/src/processors/contentGeneration.ts
+++ b/apps/worker/src/processors/contentGeneration.ts
@@ -91,7 +91,7 @@ export function createContentGenerationProcessor(deps: ContentGenerationDependen
         throw new Error('Caption generation returned empty content');
       }
 
-      const scriptPrompt = prompts.videoScriptPrompt(captionResult.content || 'A short engaging caption', durationSec);
+      const scriptPrompt = prompts.videoScriptPrompt(caption, durationSec);
       const scriptResult = await callOpenRouter(
         [
           { role: 'system', content: 'You write short timestamped scripts for short-form videos.' },


### PR DESCRIPTION
## Summary
- use the cleaned caption when constructing the video script prompt
- extend the content generation processor test to assert the caption passed to the script prompt helper

## Testing
- pnpm vitest apps/worker/src/processors/contentGeneration.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e8e3b7a11c8320b922bca6690c7c8e