### PR TITLE
Fix indentation in backlog YAML for WEB-07 issue

### DIFF
--- a/backlog/issues.yaml
+++ b/backlog/issues.yaml
@@ -1085,7 +1085,7 @@ issues:
   impact: High
   estimate: M
   code: CODE-04
-- title: 'WEB-07: Implementare l\'interfaccia progettata su Lovable.dev'
+  - title: 'WEB-07: Implementare l\'interfaccia progettata su Lovable.dev'
   body: '### Contesto
 
     È stata definita un\'interfaccia utente su Lovable.dev (mockup/prototipo). Occorre


### PR DESCRIPTION
## Summary
- fix the indentation of the WEB-07 backlog entry to restore valid YAML parsing

## Testing
- not run (js-yaml dependency not available in the current execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e91cf9a08c83209e8fe66ad6dafbcf