### PR TITLE
fix(web): define shadcn preset brand palette

### DIFF
--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,6 +1,33 @@
 import type { Config } from "tailwindcss";
 import animate from "tailwindcss-animate";
 
+const brandColors = {
+  50: "#eef2ff",
+  100: "#e0e7ff",
+  200: "#c7d2fe",
+  300: "#a5b4fc",
+  400: "#818cf8",
+  500: "#6366f1",
+  600: "#4f46e5",
+  700: "#4338ca",
+  800: "#3730a3",
+  900: "#312e81",
+  950: "#1e1b4b",
+} as const satisfies Record<number, string>;
+
+const shadcnPreset: Config = {
+  theme: {
+    extend: {
+      colors: {
+        brand: brandColors,
+      },
+      boxShadow: {
+        brand: "0 20px 45px -20px rgba(79, 70, 229, 0.55)",
+      },
+    },
+  },
+};
+
 const config: Config = {
   darkMode: "class",
   content: [


### PR DESCRIPTION
## Summary
- define the local shadcn preset before using it in the Tailwind configuration
- expose the shared brand color palette and box shadow utilities required by the application shell

## Testing
- pnpm --filter @influencerai/web lint *(fails: existing eslint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e92be70bb083209ca1e562581c7d41