### PR TITLE
Fix mode toggle to use custom theme provider

### DIFF
--- a/apps/web/src/__tests__/home.test.tsx
+++ b/apps/web/src/__tests__/home.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import Home from "../app/page";
+import { ThemeProvider } from "@/components/theme-provider";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -11,7 +12,11 @@ vi.mock("next/navigation", () => ({
 
 describe("Home page", () => {
   it("renders the dashboard headline and description", () => {
-    render(<Home />);
+    render(
+      <ThemeProvider>
+        <Home />
+      </ThemeProvider>
+    );
 
     expect(
       screen.getByRole("heading", { name: /influencerai dashboard/i })

--- a/apps/web/src/__tests__/mode-toggle.test.tsx
+++ b/apps/web/src/__tests__/mode-toggle.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+import { ModeToggle } from "@/components/mode-toggle";
+import { ThemeProvider } from "@/components/theme-provider";
+
+const STORAGE_KEY = "influencerai:theme";
+
+function mockMatchMedia(prefersDark: boolean) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+
+  const mediaQueryList: MediaQueryList = {
+    matches: prefersDark,
+    media: "(prefers-color-scheme: dark)",
+    onchange: null,
+    addEventListener: (_event, listener) => {
+      listeners.add(listener as EventListener);
+    },
+    removeEventListener: (_event, listener) => {
+      listeners.delete(listener as EventListener);
+    },
+    addListener: () => {
+      /* deprecated */
+    },
+    removeListener: () => {
+      /* deprecated */
+    },
+    dispatchEvent: () => false,
+  };
+
+  vi.stubGlobal("matchMedia", () => mediaQueryList);
+
+  return {
+    update(matches: boolean) {
+      mediaQueryList.matches = matches;
+      const event = new Event("change") as MediaQueryListEvent;
+      Object.defineProperty(event, "matches", { value: matches });
+      listeners.forEach((listener) => {
+        if (typeof listener === "function") {
+          listener(event);
+        }
+      });
+    },
+  };
+}
+
+describe("ModeToggle", () => {
+  beforeEach(() => {
+    document.documentElement.className = "";
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("toggles from light to dark mode", async () => {
+    mockMatchMedia(false);
+    const user = userEvent.setup();
+
+    render(
+      <ThemeProvider defaultTheme="light">
+        <ModeToggle />
+      </ThemeProvider>
+    );
+
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+
+    await user.click(
+      screen.getByRole("button", { name: /activate dark mode/i })
+    );
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("dark");
+  });
+
+  it("toggles from dark to light mode", async () => {
+    mockMatchMedia(true);
+    const user = userEvent.setup();
+
+    render(
+      <ThemeProvider defaultTheme="dark">
+        <ModeToggle />
+      </ThemeProvider>
+    );
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+    await user.click(
+      screen.getByRole("button", { name: /activate light mode/i })
+    );
+
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("light");
+  });
+});

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { ArrowUpRight, Sparkles } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { ModeToggle } from "../components/mode-toggle";
+import { ModeToggle } from "@/components/mode-toggle";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/apps/web/src/components/mode-toggle.tsx
+++ b/apps/web/src/components/mode-toggle.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import { useTheme } from "next-themes";
+import React from "react";
+
+import { useTheme } from "@/components/theme-provider";
 
 export function ModeToggle() {
   const { theme, setTheme, resolvedTheme } = useTheme();

--- a/apps/web/src/components/theme-provider.tsx
+++ b/apps/web/src/components/theme-provider.tsx
@@ -1,42 +1,53 @@
 "use client";
 
-import {
-  createContext,
-  type ReactNode,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React from "react";
 
 type Theme = "light" | "dark" | "system";
 
+type ResolvedTheme = Exclude<Theme, "system">;
+
 type ThemeContextValue = {
   theme: Theme;
+  resolvedTheme: ResolvedTheme;
   // eslint-disable-next-line no-unused-vars
   setTheme: (theme: Theme) => void;
 };
 
 const STORAGE_KEY = "influencerai:theme";
 
-const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+const ThemeContext = React.createContext<ThemeContextValue | undefined>(undefined);
 
-function getPreferredTheme(theme: Theme) {
-  if (typeof window === "undefined") {
-    return theme;
+function getSystemPreference(): ResolvedTheme {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return "light";
   }
-  const systemPrefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-  if (theme === "system") {
-    return systemPrefersDark ? "dark" : "light";
-  }
-  return theme;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
-export function ThemeProvider({ children, defaultTheme = "system" }: { children: ReactNode; defaultTheme?: Theme }) {
-  const [theme, setThemeState] = useState<Theme>(defaultTheme);
+function resolveTheme(theme: Theme): ResolvedTheme {
+  return theme === "system" ? getSystemPreference() : theme;
+}
 
-  useEffect(() => {
+function applyThemeToDocument(theme: ResolvedTheme) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  const root = window.document.documentElement;
+  root.classList.remove("light", "dark");
+  root.classList.add(theme);
+}
+
+export function ThemeProvider({
+  children,
+  defaultTheme = "system",
+}: {
+  children: React.ReactNode;
+  defaultTheme?: Theme;
+}) {
+  const [theme, setThemeState] = React.useState<Theme>(defaultTheme);
+  const [resolvedTheme, setResolvedTheme] = React.useState<ResolvedTheme>(() => resolveTheme(defaultTheme));
+
+  React.useEffect(() => {
     if (typeof window === "undefined") return;
     const stored = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
     if (stored) {
@@ -44,40 +55,53 @@ export function ThemeProvider({ children, defaultTheme = "system" }: { children:
     }
   }, []);
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const root = window.document.documentElement;
-    const activeTheme = getPreferredTheme(theme);
-    root.classList.remove("light", "dark");
-    root.classList.add(activeTheme);
+  React.useEffect(() => {
+    const activeTheme = resolveTheme(theme);
+    setResolvedTheme(activeTheme);
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    applyThemeToDocument(activeTheme);
     window.localStorage.setItem(STORAGE_KEY, theme);
-  }, [theme]);
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
+    if (theme !== "system" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    const handler = () => {
-      if (theme === "system") {
-        const root = window.document.documentElement;
-        root.classList.toggle("dark", mediaQuery.matches);
-        root.classList.toggle("light", !mediaQuery.matches);
-      }
+    const handleChange = (event: MediaQueryListEvent) => {
+      const nextTheme = event.matches ? "dark" : "light";
+      setResolvedTheme(nextTheme);
+      applyThemeToDocument(nextTheme);
     };
-    mediaQuery.addEventListener("change", handler);
-    return () => mediaQuery.removeEventListener("change", handler);
+
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleChange);
+    };
   }, [theme]);
 
-  const setTheme = useCallback((value: Theme) => {
+  const setTheme = React.useCallback((value: Theme) => {
     setThemeState(value);
   }, []);
 
-  const value = useMemo(() => ({ theme, setTheme }), [theme, setTheme]);
+  const value = React.useMemo(
+    () => ({
+      theme,
+      resolvedTheme,
+      setTheme,
+    }),
+    [theme, resolvedTheme, setTheme]
+  );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }
 
 export function useTheme() {
-  const context = useContext(ThemeContext);
+  const context = React.useContext(ThemeContext);
   if (!context) {
     throw new Error("useTheme must be used within a ThemeProvider");
   }


### PR DESCRIPTION
## Summary
- extend the custom theme provider to expose a resolved theme and sync html classes/local storage
- update the mode toggle and home page to rely on the shared provider and correct import paths
- add targeted tests covering theme toggling and wrap the home page test with the provider

## Testing
- pnpm --filter @influencerai/web test -- mode-toggle

------
https://chatgpt.com/codex/tasks/task_e_68e92c8774208320b9b2d870333a343d