### PR TITLE
fix(web): provide shadcn tailwind preset and brand palette

### DIFF
--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,32 +1,7 @@
 import type { Config } from "tailwindcss";
 import animate from "tailwindcss-animate";
 
-const brandColors = {
-  50: "#eef2ff",
-  100: "#e0e7ff",
-  200: "#c7d2fe",
-  300: "#a5b4fc",
-  400: "#818cf8",
-  500: "#6366f1",
-  600: "#4f46e5",
-  700: "#4338ca",
-  800: "#3730a3",
-  900: "#312e81",
-  950: "#1e1b4b",
-} as const satisfies Record<number, string>;
-
-const shadcnPreset: Config = {
-  theme: {
-    extend: {
-      colors: {
-        brand: brandColors,
-      },
-      boxShadow: {
-        brand: "0 20px 45px -20px rgba(79, 70, 229, 0.55)",
-      },
-    },
-  },
-};
+import { shadcnPreset } from "./tailwind.preset";
 
 const config: Config = {
   darkMode: "class",

--- a/apps/web/tailwind.preset.ts
+++ b/apps/web/tailwind.preset.ts
@@ -1,0 +1,28 @@
+import type { Config } from "tailwindcss";
+
+const brandColors = {
+  50: "#eef2ff",
+  100: "#e0e7ff",
+  200: "#c7d2fe",
+  300: "#a5b4fc",
+  400: "#818cf8",
+  500: "#6366f1",
+  600: "#4f46e5",
+  700: "#4338ca",
+  800: "#3730a3",
+  900: "#312e81",
+  950: "#1e1b4b",
+} as const satisfies Record<number, string>;
+
+export const shadcnPreset: Config = {
+  theme: {
+    extend: {
+      colors: {
+        brand: brandColors,
+      },
+      boxShadow: {
+        brand: "0 20px 45px -20px rgba(79, 70, 229, 0.55)",
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- add a Tailwind preset that exposes the shadcn brand color scale and box shadow used by shared UI
- consume the preset from the web Tailwind config so brand utilities are generated for the app

## Testing
- pnpm --filter @influencerai/web build *(fails: Next.js cannot download Google Fonts and reports a pre-existing duplicate identifier in src/lib/api.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e92d0f981c83208a8839f94bd7bec2