### PR TITLE
test: add coverage for shared packages

### DIFF
--- a/packages/core-schemas/src/index.test.ts
+++ b/packages/core-schemas/src/index.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ContentPlanSchema,
+  DatasetSpecSchema,
+  JobSpecSchema,
+  LoRAConfigSchema,
+  QueueSummarySchema,
+} from './index';
+
+describe('core schemas', () => {
+  it('validates queue summaries', () => {
+    const parsed = QueueSummarySchema.parse({ active: 2, waiting: 1, failed: 0 });
+    expect(parsed).toEqual({ active: 2, waiting: 1, failed: 0 });
+    expect(() => QueueSummarySchema.parse({ active: -1, waiting: 0, failed: 0 })).toThrowError();
+  });
+
+  it('applies defaults for job specs', () => {
+    const spec = JobSpecSchema.parse({
+      type: 'content-generation',
+      payload: { prompt: 'hello' },
+    });
+    expect(spec.priority).toBe(5);
+    expect(() =>
+      JobSpecSchema.parse({
+        // @ts-expect-error priority should be number
+        type: 'content-generation',
+        payload: 'invalid',
+      })
+    ).toThrowError();
+  });
+
+  it('validates content plan structure', () => {
+    const plan = ContentPlanSchema.parse({
+      influencerId: 'abc',
+      theme: 'fitness',
+      targetPlatforms: ['instagram', 'tiktok'],
+      posts: [
+        {
+          caption: 'Stay strong',
+          hashtags: ['#fit'],
+          scheduledAt: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+      createdAt: '2024-01-01T00:00:00.000Z',
+    });
+    expect(plan.posts).toHaveLength(1);
+    expect(() =>
+      ContentPlanSchema.parse({
+        influencerId: 'abc',
+        theme: 'fitness',
+        targetPlatforms: ['myspace'],
+        posts: [],
+        createdAt: '2024-01-01T00:00:00.000Z',
+      })
+    ).toThrowError();
+  });
+
+  it('validates dataset specification', () => {
+    const dataset = DatasetSpecSchema.parse({
+      name: 'fitness-photos',
+      kind: 'lora-training',
+      path: '/tmp/data',
+      imageCount: 10,
+      captioned: true,
+      meta: { source: 'user' },
+    });
+    expect(dataset.meta).toEqual({ source: 'user' });
+    expect(() =>
+      DatasetSpecSchema.parse({
+        name: 'bad',
+        kind: 'lora-training',
+        path: '/tmp/data',
+        imageCount: 0,
+        captioned: true,
+      })
+    ).toThrowError();
+  });
+
+  it('applies defaults for LoRA config', () => {
+    const config = LoRAConfigSchema.parse({
+      modelName: 'sd',
+      datasetPath: '/dataset',
+      outputPath: '/output',
+    });
+    expect(config.epochs).toBe(10);
+    expect(config.learningRate).toBeGreaterThan(0);
+    expect(() =>
+      LoRAConfigSchema.parse({
+        modelName: 'sd',
+        datasetPath: '/dataset',
+        outputPath: '/output',
+        // @ts-expect-error invalid batch size
+        batchSize: 0,
+      })
+    ).toThrowError();
+  });
+});

--- a/packages/prompts/src/index.test.ts
+++ b/packages/prompts/src/index.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { contentPlanPrompt, imageCaptionPrompt, videoScriptPrompt } from './index';
+
+describe('prompt templates', () => {
+  it('generates content plan prompt with persona and theme', () => {
+    const prompt = contentPlanPrompt('Energetic fitness coach', 'Strength training');
+    expect(prompt).toContain('Energetic fitness coach');
+    expect(prompt).toContain('Strength training');
+    expect(prompt).toContain('Generate 3-5 post ideas');
+  });
+
+  it('generates caption prompt with guidance', () => {
+    const prompt = imageCaptionPrompt('Sunset yoga session');
+    expect(prompt).toContain('Sunset yoga session');
+    expect(prompt).toContain('Provide a concise, detailed caption');
+    expect(prompt.split('\n')).toContain('- Lighting and atmosphere');
+  });
+
+  it('generates video script prompt with duration and caption', () => {
+    const prompt = videoScriptPrompt('Try this HIIT routine!', 30);
+    expect(prompt).toContain('30-second video script');
+    expect(prompt).toContain('Try this HIIT routine!');
+    expect(prompt).toContain('Opening hook');
+    expect(prompt).toContain('Format as timestamped beats.');
+  });
+});

--- a/packages/sdk/src/fetch-utils.test.ts
+++ b/packages/sdk/src/fetch-utils.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { APIError, fetchWithTimeout, handleResponse } from './fetch-utils';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('handleResponse', () => {
+  const createResponse = (overrides: Partial<Response>) => ({
+    ok: true,
+    status: 200,
+    headers: {
+      get: vi.fn().mockReturnValue('application/json'),
+    },
+    json: vi.fn().mockResolvedValue({ ok: true }),
+    text: vi.fn().mockResolvedValue('ok'),
+    ...overrides,
+  });
+
+  it('parses json body on success', async () => {
+    const response = createResponse({});
+    const result = await handleResponse<{ ok: boolean }>(response);
+    expect(result).toEqual({ ok: true });
+    expect(response.json).toHaveBeenCalled();
+  });
+
+  it('parses text when content type is not json', async () => {
+    const response = createResponse({
+      headers: { get: vi.fn().mockReturnValue('text/plain') },
+    });
+    const result = await handleResponse<string>(response);
+    expect(result).toBe('ok');
+    expect(response.text).toHaveBeenCalled();
+  });
+
+  it('throws APIError on failure with parsed body when available', async () => {
+    const response = createResponse({
+      ok: false,
+      status: 500,
+      json: vi.fn().mockResolvedValue({ message: 'boom' }),
+    });
+    await expect(handleResponse(response)).rejects.toMatchObject({
+      status: 500,
+      body: { message: 'boom' },
+    });
+  });
+});
+
+describe('fetchWithTimeout', () => {
+  it('returns fetch response when successful', async () => {
+    const mockResponse = { ok: true };
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+    vi.stubGlobal('fetch', mockFetch);
+    const response = await fetchWithTimeout('http://example.com', { method: 'POST' }, 50);
+    expect(response).toBe(mockResponse);
+    expect(mockFetch).toHaveBeenCalledWith('http://example.com', expect.objectContaining({ method: 'POST' }));
+  });
+
+  it('throws APIError on timeout', async () => {
+    vi.useFakeTimers();
+    const abortableFetch = vi.fn((_, init: RequestInit) =>
+      new Promise((_, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const error = new Error('Aborted');
+          error.name = 'AbortError';
+          reject(error);
+        });
+      })
+    );
+    vi.stubGlobal('fetch', abortableFetch);
+
+    const promise = fetchWithTimeout('http://slow.test', undefined, 100);
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(promise).rejects.toBeInstanceOf(APIError);
+    await expect(promise).rejects.toMatchObject({ status: 408, url: 'http://slow.test', method: 'GET' });
+  });
+
+  it('wraps network errors in APIError', async () => {
+    const networkError = new Error('boom');
+    const failingFetch = vi.fn().mockRejectedValue(networkError);
+    vi.stubGlobal('fetch', failingFetch);
+
+    await expect(fetchWithTimeout('http://broken.test', { method: 'DELETE' }, 50)).rejects.toMatchObject({
+      status: 0,
+      url: 'http://broken.test',
+      method: 'DELETE',
+    });
+  });
+});

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { InfluencerAIClient } from './index';
+import { APIError } from './fetch-utils';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('InfluencerAIClient', () => {
+  const createMockResponse = (body: unknown, init?: Partial<Response>) => ({
+    ok: true,
+    status: 200,
+    headers: {
+      get: () => 'application/json',
+    },
+    json: vi.fn().mockResolvedValue(body),
+    text: vi.fn(),
+    ...init,
+  });
+
+  it('creates a job and validates response', async () => {
+    const mockResponse = createMockResponse({ id: 'job-1', status: 'pending' });
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new InfluencerAIClient('http://api.test');
+    const result = await client.createJob({ type: 'content-generation', payload: {} });
+
+    expect(result.id).toBe('job-1');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://api.test/jobs',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+  });
+
+  it('throws APIError when job response is missing id', async () => {
+    const mockResponse = createMockResponse({ status: 'pending' });
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new InfluencerAIClient('http://api.test');
+    await expect(client.createJob({ type: 'content-generation', payload: {} })).rejects.toBeInstanceOf(APIError);
+  });
+
+  it('validates queue summary shape', async () => {
+    const mockResponse = createMockResponse({ active: 1, waiting: 2, failed: 0 });
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new InfluencerAIClient('http://api.test');
+    const summary = await client.getQueuesSummary();
+    expect(summary).toEqual({ active: 1, waiting: 2, failed: 0 });
+
+    mockFetch.mockResolvedValueOnce(createMockResponse({ active: '1', waiting: 2, failed: 0 }));
+    await expect(client.getQueuesSummary()).rejects.toBeInstanceOf(APIError);
+  });
+
+  it('uses default base url when none provided', async () => {
+    const mockResponse = createMockResponse({ id: 'job-2' });
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new InfluencerAIClient();
+    await client.createJob({ type: 'content-generation', payload: {} });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3001/jobs');
+  });
+});


### PR DESCRIPTION
## Summary
- add validation coverage for core schema definitions
- verify prompt templates include persona, theme, and guidance details
- cover SDK client and fetch utilities for success, validation, and failure flows

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ee32a1933c83209dcec2a5dba1638a