### PR TITLE
feat: extend SDK client for jobs, datasets, and plans

### DIFF
--- a/packages/sdk/src/core-schemas.ts
+++ b/packages/sdk/src/core-schemas.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+export const QueueSummarySchema = z.object({
+  active: z.number().int().nonnegative(),
+  waiting: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+});
+export type QueueSummary = z.infer<typeof QueueSummarySchema>;
+
+export const JobSpecSchema = z.object({
+  type: z.enum(['content-generation', 'lora-training', 'video-generation']),
+  priority: z.number().min(0).max(10).default(5),
+  payload: z.record(z.any()),
+});
+export type JobSpec = z.infer<typeof JobSpecSchema>;
+
+export const ContentPlanSchema = z.object({
+  influencerId: z.string(),
+  theme: z.string(),
+  targetPlatforms: z.array(z.enum(['instagram', 'tiktok', 'youtube'])),
+  posts: z.array(
+    z.object({
+      caption: z.string(),
+      hashtags: z.array(z.string()),
+      scheduledAt: z.string().datetime().optional(),
+    })
+  ),
+  createdAt: z.string().datetime(),
+});
+export type ContentPlan = z.infer<typeof ContentPlanSchema>;
+
+export const DatasetSpecSchema = z.object({
+  name: z.string(),
+  kind: z.enum(['lora-training', 'reference']),
+  path: z.string(),
+  imageCount: z.number().int().positive(),
+  captioned: z.boolean(),
+  meta: z.record(z.any()).optional(),
+});
+export type DatasetSpec = z.infer<typeof DatasetSpecSchema>;
+
+export const LoRAConfigSchema = z.object({
+  modelName: z.string(),
+  datasetPath: z.string(),
+  outputPath: z.string(),
+  epochs: z.number().int().positive().default(10),
+  learningRate: z.number().positive().default(1e-4),
+  batchSize: z.number().int().positive().default(1),
+  resolution: z.number().int().positive().default(512),
+  networkDim: z.number().int().positive().default(32),
+  networkAlpha: z.number().int().positive().default(16),
+});
+export type LoRAConfig = z.infer<typeof LoRAConfigSchema>;

--- a/packages/sdk/src/fetch-utils.ts
+++ b/packages/sdk/src/fetch-utils.ts
@@ -1,3 +1,11 @@
+export interface APIErrorOptions {
+  status: number;
+  body?: unknown;
+  url?: string;
+  method?: string;
+  cause?: unknown;
+}
+
 export class APIError extends Error {
   readonly status: number;
   readonly body?: unknown;
@@ -5,7 +13,7 @@ export class APIError extends Error {
   readonly method?: string;
   readonly isAPIError = true as const;
 
-  constructor(message: string, opts: { status: number; body?: unknown; url?: string; method?: string; cause?: unknown } = { status: 0 }) {
+  constructor(message: string, opts: APIErrorOptions = { status: 0 }) {
     super(message);
     this.name = 'APIError';
     this.status = opts.status;
@@ -19,6 +27,99 @@ export class APIError extends Error {
   }
 }
 
+export class ClientError extends APIError {
+  constructor(message: string, opts: APIErrorOptions) {
+    super(message, opts);
+    this.name = 'ClientError';
+  }
+}
+
+export class ServerError extends APIError {
+  constructor(message: string, opts: APIErrorOptions) {
+    super(message, opts);
+    this.name = 'ServerError';
+  }
+}
+
+export class BadRequestError extends ClientError {
+  constructor(opts: APIErrorOptions) {
+    super('Bad request', opts);
+    this.name = 'BadRequestError';
+  }
+}
+
+export class UnauthorizedError extends ClientError {
+  constructor(opts: APIErrorOptions) {
+    super('Unauthorized', opts);
+    this.name = 'UnauthorizedError';
+  }
+}
+
+export class ForbiddenError extends ClientError {
+  constructor(opts: APIErrorOptions) {
+    super('Forbidden', opts);
+    this.name = 'ForbiddenError';
+  }
+}
+
+export class NotFoundError extends ClientError {
+  constructor(opts: APIErrorOptions) {
+    super('Resource not found', opts);
+    this.name = 'NotFoundError';
+  }
+}
+
+export class ConflictError extends ClientError {
+  constructor(opts: APIErrorOptions) {
+    super('Conflict', opts);
+    this.name = 'ConflictError';
+  }
+}
+
+export class UnprocessableEntityError extends ClientError {
+  constructor(opts: APIErrorOptions) {
+    super('Unprocessable entity', opts);
+    this.name = 'UnprocessableEntityError';
+  }
+}
+
+export class TooManyRequestsError extends ClientError {
+  constructor(opts: APIErrorOptions) {
+    super('Too many requests', opts);
+    this.name = 'TooManyRequestsError';
+  }
+}
+
+export class RequestTimeoutError extends ClientError {
+  constructor(opts: APIErrorOptions) {
+    super('Request timed out', opts);
+    this.name = 'RequestTimeoutError';
+  }
+}
+
+export class NetworkError extends APIError {
+  constructor(opts: APIErrorOptions) {
+    super('Network error', opts);
+    this.name = 'NetworkError';
+  }
+}
+
+type ErrorFactory = (opts: APIErrorOptions) => APIError;
+
+function resolveErrorFactory(status: number): ErrorFactory {
+  if (status === 400) return (opts) => new BadRequestError(opts);
+  if (status === 401) return (opts) => new UnauthorizedError(opts);
+  if (status === 403) return (opts) => new ForbiddenError(opts);
+  if (status === 404) return (opts) => new NotFoundError(opts);
+  if (status === 409) return (opts) => new ConflictError(opts);
+  if (status === 422) return (opts) => new UnprocessableEntityError(opts);
+  if (status === 429) return (opts) => new TooManyRequestsError(opts);
+  if (status === 408) return (opts) => new RequestTimeoutError(opts);
+  if (status >= 500 && status <= 599) return (opts) => new ServerError('Server error', opts);
+  if (status >= 400 && status <= 499) return (opts) => new ClientError('Client error', opts);
+  return (opts) => new APIError('Request failed', opts);
+}
+
 export async function handleResponse<T = unknown>(response: any): Promise<T> {
   const contentType = (response.headers?.get?.('content-type') || '') as string;
   const isJson = typeof contentType === 'string' && contentType.includes('application/json');
@@ -30,15 +131,13 @@ export async function handleResponse<T = unknown>(response: any): Promise<T> {
     } catch (_) {
       // ignore body parse errors
     }
-    throw new APIError(
-      `Request failed with status ${response.status}`,
-      {
-        status: response.status,
-        body: errorBody,
-        url: response.url,
-        method: (response as unknown as { method?: string }).method,
-      }
-    );
+    const createError = resolveErrorFactory(response.status ?? 0);
+    throw createError({
+      status: response.status ?? 0,
+      body: errorBody,
+      url: response.url,
+      method: (response as unknown as { method?: string }).method,
+    });
   }
 
   // Success path
@@ -59,9 +158,9 @@ export async function fetchWithTimeout(input: any, init: any = {}, timeoutMs = 3
     // Abort or network error
     const url = typeof input === 'string' ? input : String(input);
     if ((err as Error)?.name === 'AbortError') {
-      throw new APIError('Request timed out', { status: 408, url, method, cause: err });
+      throw new RequestTimeoutError({ status: 408, url, method, cause: err });
     }
-    throw new APIError('Network error', { status: 0, url, method, cause: err });
+    throw new NetworkError({ status: 0, url, method, cause: err });
   } finally {
     clearTimeout(timeout);
   }

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -24,7 +24,7 @@ describe('InfluencerAIClient', () => {
     vi.stubGlobal('fetch', mockFetch);
 
     const client = new InfluencerAIClient('http://api.test');
-    const result = await client.createJob({ type: 'content-generation', payload: {} });
+    const result = await client.createJob({ type: 'content-generation', payload: {}, priority: 5 });
 
     expect(result.id).toBe('job-1');
     expect(mockFetch).toHaveBeenCalledWith(
@@ -42,7 +42,9 @@ describe('InfluencerAIClient', () => {
     vi.stubGlobal('fetch', mockFetch);
 
     const client = new InfluencerAIClient('http://api.test');
-    await expect(client.createJob({ type: 'content-generation', payload: {} })).rejects.toBeInstanceOf(APIError);
+    await expect(
+      client.createJob({ type: 'content-generation', payload: {}, priority: 5 })
+    ).rejects.toBeInstanceOf(APIError);
   });
 
   it('validates queue summary shape', async () => {
@@ -64,7 +66,114 @@ describe('InfluencerAIClient', () => {
     vi.stubGlobal('fetch', mockFetch);
 
     const client = new InfluencerAIClient();
-    await client.createJob({ type: 'content-generation', payload: {} });
+    await client.createJob({ type: 'content-generation', payload: {}, priority: 5 });
     expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3001/jobs');
+  });
+
+  it('lists jobs with optional filters and validates response shape', async () => {
+    const mockResponse = createMockResponse([
+      { id: 'job-1', type: 'content-generation', status: 'pending' },
+      { id: 'job-2', type: 'content-generation', status: 'running' },
+    ]);
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new InfluencerAIClient('http://api.test');
+    const result = await client.listJobs({ status: 'pending', take: 5 });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ id: 'job-1' });
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://api.test/jobs?status=pending&take=5',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('throws when jobs response has unexpected shape', async () => {
+    const mockResponse = createMockResponse({});
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new InfluencerAIClient('http://api.test');
+    await expect(client.listJobs()).rejects.toBeInstanceOf(APIError);
+  });
+
+  it('updates a job and returns validated payload', async () => {
+    const mockResponse = createMockResponse({ id: 'job-1', status: 'succeeded' });
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new InfluencerAIClient('http://api.test');
+    const result = await client.updateJob('job-1', { status: 'succeeded' });
+
+    expect(result).toMatchObject({ id: 'job-1', status: 'succeeded' });
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://api.test/jobs/job-1',
+      expect.objectContaining({ method: 'PATCH' })
+    );
+  });
+
+  it('lists datasets and validates payload structure', async () => {
+    const datasets = [
+      {
+        id: 'ds-1',
+        kind: 'lora-training',
+        path: 'datasets/tenant/ds-1/file.zip',
+        status: 'pending',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        meta: { filename: 'file.zip' },
+      },
+    ];
+    const mockResponse = createMockResponse(datasets);
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new InfluencerAIClient('http://api.test');
+    const result = await client.listDatasets();
+
+    expect(result).toEqual(datasets);
+    expect(mockFetch).toHaveBeenCalledWith('http://api.test/datasets', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('creates a dataset and returns upload information', async () => {
+    const payload = { id: 'ds-1', uploadUrl: 'https://upload', key: 'datasets/tenant/ds-1/file.zip', bucket: 'uploads' };
+    const mockResponse = createMockResponse(payload);
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new InfluencerAIClient('http://api.test');
+    const result = await client.createDataset({ kind: 'lora-training', filename: 'file.zip' });
+
+    expect(result).toEqual(payload);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://api.test/datasets',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ kind: 'lora-training', filename: 'file.zip' }),
+      })
+    );
+  });
+
+  it('retrieves a content plan by id and validates shape', async () => {
+    const plan = {
+      id: 'plan-1',
+      plan: {
+        influencerId: 'inf-1',
+        theme: 'summer vibes',
+        targetPlatforms: ['instagram'],
+        posts: [{ caption: 'hello', hashtags: ['#summer'] }],
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+    };
+    const mockResponse = createMockResponse(plan);
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new InfluencerAIClient('http://api.test');
+    const result = await client.getContentPlan('plan-1');
+
+    expect(result).toEqual(plan);
+    expect(mockFetch).toHaveBeenCalledWith('http://api.test/content-plans/plan-1', expect.objectContaining({ method: 'GET' }));
   });
 });

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,18 +1,67 @@
-export interface JobResponse {
-  id: string;
-  type?: string;
-  status?: 'pending' | 'running' | 'succeeded' | 'failed' | 'completed' | string;
-  payload?: unknown;
-  result?: unknown;
-  createdAt?: string;
-  priority?: number;
-  parentJobId?: string;
-}
+import { z } from 'zod';
+import { ContentPlanSchema } from './core-schemas';
 
-// JobResponse is exported via the `export interface JobResponse` declaration above.
+export const JobResponseSchema = z.object({
+  id: z.string(),
+  type: z.string().optional(),
+  status: z
+    .enum(['pending', 'running', 'succeeded', 'failed', 'completed'])
+    .or(z.string())
+    .optional(),
+  payload: z.unknown().optional(),
+  result: z.unknown().optional(),
+  createdAt: z.string().datetime().optional(),
+  updatedAt: z.string().datetime().optional(),
+  priority: z.number().optional(),
+  parentJobId: z.string().optional(),
+  costTok: z.number().optional(),
+});
+
+export type JobResponse = z.infer<typeof JobResponseSchema>;
+
+export const JobListSchema = z.array(JobResponseSchema);
 
 export interface QueueSummary {
   active: number;
   waiting: number;
   failed: number;
 }
+
+export const DatasetSchema = z.object({
+  id: z.string(),
+  kind: z.string(),
+  path: z.string(),
+  status: z.string(),
+  meta: z.record(z.unknown()).optional(),
+  createdAt: z.string().datetime().optional(),
+  updatedAt: z.string().datetime().optional(),
+});
+
+export type Dataset = z.infer<typeof DatasetSchema>;
+
+export const DatasetListSchema = z.array(DatasetSchema);
+
+export const CreateDatasetInputSchema = z.object({
+  kind: z.string().min(1),
+  filename: z.string().min(1),
+  contentType: z.string().min(1).optional(),
+  meta: z.record(z.unknown()).optional(),
+});
+
+export type CreateDatasetInput = z.infer<typeof CreateDatasetInputSchema>;
+
+export const DatasetCreationSchema = z.object({
+  id: z.string(),
+  uploadUrl: z.string().min(1),
+  key: z.string(),
+  bucket: z.string(),
+});
+
+export type CreateDatasetResponse = z.infer<typeof DatasetCreationSchema>;
+
+export const ContentPlanEnvelopeSchema = z.object({
+  id: z.string(),
+  plan: ContentPlanSchema,
+});
+
+export type ContentPlanEnvelope = z.infer<typeof ContentPlanEnvelopeSchema>;

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -63,8 +63,11 @@ describe('InfluencerAIClient error handling', () => {
     fetchWithTimeoutSpy.mockResolvedValue(response);
     handleResponseSpy.mockResolvedValue([{ id: 'job-1' }] as any);
     const result = await client.listJobs();
-    expect(fetchWithTimeoutSpy).toHaveBeenCalledWith('https://api.test.example/jobs');
-    expect(fetchWithTimeoutSpy.mock.calls[0][1]).toBeUndefined();
+    expect(fetchWithTimeoutSpy).toHaveBeenCalledWith(
+      'https://api.test.example/jobs',
+      expect.objectContaining({ method: 'GET' }),
+      undefined
+    );
     expect(handleResponseSpy).toHaveBeenCalledWith(response);
     expect(result).toEqual([{ id: 'job-1' }]);
   });
@@ -73,15 +76,15 @@ describe('InfluencerAIClient error handling', () => {
     const response = {} as Response;
     const update = { status: 'done' };
     fetchWithTimeoutSpy.mockResolvedValue(response);
-    handleResponseSpy.mockResolvedValue({ ok: true } as any);
+    handleResponseSpy.mockResolvedValue({ id: 'job-42', status: 'done' } as any);
     const result = await client.updateJob('job-42', update);
     expect(fetchWithTimeoutSpy).toHaveBeenCalledWith('https://api.test.example/jobs/job-42', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(update),
-    });
+    }, undefined);
     expect(handleResponseSpy).toHaveBeenCalledWith(response);
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({ id: 'job-42', status: 'done' });
   });
 
   it('getQueuesSummary fetches queue summary and validates shape', async () => {
@@ -91,7 +94,11 @@ describe('InfluencerAIClient error handling', () => {
 
     const result = await client.getQueuesSummary();
 
-    expect(fetchWithTimeoutSpy).toHaveBeenCalledWith('https://api.test.example/queues/summary');
+    expect(fetchWithTimeoutSpy).toHaveBeenCalledWith(
+      'https://api.test.example/queues/summary',
+      expect.objectContaining({ method: 'GET' }),
+      undefined
+    );
     expect(handleResponseSpy).toHaveBeenCalledWith(response);
     expect(result).toEqual({ active: 3, waiting: 4, failed: 1 });
   });
@@ -108,15 +115,28 @@ describe('InfluencerAIClient error handling', () => {
     const response = {} as Response;
     const plan = { title: 'Plan' } as any;
     fetchWithTimeoutSpy.mockResolvedValue(response);
-    handleResponseSpy.mockResolvedValue({ id: 'plan-1' } as any);
+    handleResponseSpy.mockResolvedValue({
+      id: 'plan-1',
+      plan: {
+        influencerId: 'inf-1',
+        theme: 'theme',
+        targetPlatforms: ['instagram'],
+        posts: [],
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+    } as any);
     const result = await client.createContentPlan(plan);
-    expect(fetchWithTimeoutSpy).toHaveBeenCalledWith('https://api.test.example/content-plans', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(plan),
-    });
+    expect(fetchWithTimeoutSpy).toHaveBeenCalledWith(
+      'https://api.test.example/content-plans',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(plan),
+      },
+      undefined
+    );
     expect(handleResponseSpy).toHaveBeenCalledWith(response);
-    expect(result).toEqual({ id: 'plan-1' });
+    expect(result).toMatchObject({ id: 'plan-1' });
   });
 
   it('health checks API status via fetchWithTimeout and handleResponse', async () => {
@@ -124,8 +144,11 @@ describe('InfluencerAIClient error handling', () => {
     fetchWithTimeoutSpy.mockResolvedValue(response);
     handleResponseSpy.mockResolvedValue({ status: 'ok' } as any);
     const result = await client.health();
-    expect(fetchWithTimeoutSpy).toHaveBeenCalledWith('https://api.test.example/health');
-    expect(fetchWithTimeoutSpy.mock.calls[0][1]).toBeUndefined();
+    expect(fetchWithTimeoutSpy).toHaveBeenCalledWith(
+      'https://api.test.example/health',
+      expect.objectContaining({ method: 'GET' }),
+      undefined
+    );
     expect(handleResponseSpy).toHaveBeenCalledWith(response);
     expect(result).toEqual({ status: 'ok' });
   });

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,11 +1,17 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
 
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['test/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'test/**/*.test.ts'],
     typecheck: {
       tsconfig: './tsconfig.vitest.json',
+    },
+  },
+  resolve: {
+    alias: {
+      '@influencerai/core-schemas': resolve(__dirname, '../core-schemas/src'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- implement local schema helpers and expose new SDK methods for listing jobs, datasets, and retrieving content plans
- add typed HTTP error hierarchy with expanded unit coverage for error translation and client-side workflows
- configure Vitest aliasing for core schemas and ensure SDK build/tests cover new capabilities

## Testing
- pnpm --filter @influencerai/sdk test
- pnpm --filter @influencerai/sdk build

Closes SDK-01

------
https://chatgpt.com/codex/tasks/task_e_68ee452410ac8320a8700ff8bda1d716