### PR TITLE
fix: enforce OpenRouter API key validation

### DIFF
--- a/apps/api/src/config/__tests__/env.validation.spec.ts
+++ b/apps/api/src/config/__tests__/env.validation.spec.ts
@@ -6,7 +6,10 @@ describe('validateEnv', () => {
   });
 
   it('applies defaults for optional values', () => {
-    const env = validateEnv({ DATABASE_URL: 'postgresql://user:pass@localhost:5432/db' });
+    const env = validateEnv({
+      DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
+      OPENROUTER_API_KEY: 'sk-test',
+    });
 
     expect(env.REDIS_URL).toBe('redis://localhost:6379');
     expect(env.OPENROUTER_MAX_RETRIES).toBe(3);
@@ -24,11 +27,41 @@ describe('validateEnv', () => {
       DISABLE_BULL: '1',
       SKIP_S3_INIT: 'true',
       LOGGER_PRETTY: '0',
+      OPENROUTER_API_KEY: 'sk-test',
     });
 
     expect(env.BULL_ENABLED).toBe(false);
     expect(env.SKIP_S3_INIT).toBe(true);
     expect(env.LOGGER_PRETTY).toBe(false);
     expect(env.LOG_LEVEL).toBe('info');
+  });
+
+  it('throws when OPENROUTER_API_KEY is missing outside test environments', () => {
+    expect(() =>
+      validateEnv({
+        DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
+        NODE_ENV: 'production',
+      }),
+    ).toThrow(/OPENROUTER_API_KEY/);
+  });
+
+  it('allows missing OPENROUTER_API_KEY in test environment only', () => {
+    const env = validateEnv({
+      DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
+      NODE_ENV: 'test',
+    });
+
+    expect(env.NODE_ENV).toBe('test');
+    expect(env.OPENROUTER_API_KEY).toBe('');
+  });
+
+  it('trims the OPENROUTER_API_KEY value', () => {
+    const env = validateEnv({
+      DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
+      NODE_ENV: 'development',
+      OPENROUTER_API_KEY: '  sk-test  ',
+    });
+
+    expect(env.OPENROUTER_API_KEY).toBe('sk-test');
   });
 });

--- a/apps/api/src/content-plans/content-plans.service.spec.ts
+++ b/apps/api/src/content-plans/content-plans.service.spec.ts
@@ -14,7 +14,10 @@ describe('ContentPlansService', () => {
     // Configure prisma mocks
     prismaMock.influencer.findUnique.mockImplementation(async ({ where: { id } }: any) => (id === 'inf_1' ? { id, tenantId: 'ten_1', persona: { name: 'A' } } : null));
     prismaMock.job.create.mockImplementation(async ({ data }: any) => ({ id: 'job_cp_1', ...data }));
-    configValues = validateEnv({ DATABASE_URL: 'postgresql://user:pass@localhost:5432/db' });
+    configValues = validateEnv({
+      DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
+      OPENROUTER_API_KEY: 'sk-test',
+    });
     config = {
       get: jest.fn((key: keyof AppConfig) => configValues[key]),
     } as unknown as ConfigService<AppConfig, true>;

--- a/apps/api/src/jobs/jobs.service.spec.ts
+++ b/apps/api/src/jobs/jobs.service.spec.ts
@@ -7,7 +7,10 @@ import { JobSeriesQuerySchema } from './dto';
 import { AppConfig, validateEnv } from '../config/env.validation';
 
 function createConfigService(overrides: Partial<AppConfig> = {}): ConfigService<AppConfig, true> {
-  const base = validateEnv({ DATABASE_URL: 'postgresql://user:pass@localhost:5432/db' });
+  const base = validateEnv({
+    DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
+    OPENROUTER_API_KEY: 'sk-test',
+  });
   const values: AppConfig = { ...base, ...overrides };
   return {
     get: jest.fn((key: keyof AppConfig) => values[key]),

--- a/apps/api/src/prisma/prisma.service.spec.ts
+++ b/apps/api/src/prisma/prisma.service.spec.ts
@@ -107,7 +107,10 @@ const runWithContext = async <T>(ctx: Record<string, any>, fn: () => Promise<T>)
 describe('PrismaService', () => {
   const databaseUrl = 'postgresql://user:pass@localhost:5432/db?schema=public';
 
-  const baseConfig = validateEnv({ DATABASE_URL: databaseUrl });
+  const baseConfig = validateEnv({
+    DATABASE_URL: databaseUrl,
+    OPENROUTER_API_KEY: 'sk-test',
+  });
 
   const createConfigService = (value?: string): ConfigService<AppConfig, true> => {
     return {


### PR DESCRIPTION
## Summary
- enforce configuration validation that requires OPENROUTER_API_KEY outside of test environments and normalises whitespace
- update related unit tests to reflect the stricter validation and provide fixtures with explicit keys

## Testing
- pnpm --filter @influencerai/api test:unit

------
https://chatgpt.com/codex/tasks/task_e_68ee5d4a82788320b27ea8c0de286d4b