### PR TITLE
Centralize CI workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     outputs:
       base_sha: ${{ steps.detect.outputs.base_sha }}
       head_sha: ${{ steps.detect.outputs.head_sha }}
+      backlog_changed: ${{ steps.backlog.outputs.changed }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -49,6 +50,27 @@ jobs:
 
           echo "base_sha=${BASE_SHA}" >> "$GITHUB_OUTPUT"
           echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Detect backlog changes
+        id: backlog
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE="${{ steps.detect.outputs.base_sha }}"
+          HEAD="${{ steps.detect.outputs.head_sha }}"
+          if [[ -z "${HEAD}" ]]; then
+            HEAD="$(git rev-parse HEAD)"
+          fi
+          if [[ -n "${BASE}" ]]; then
+            DIFF=$(git diff --name-only "${BASE}" "${HEAD}")
+          else
+            DIFF=$(git show --name-only --pretty='' "${HEAD}")
+          fi
+          if echo "${DIFF}" | grep -q '^backlog/issues.yaml$'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
 
   lint:
     name: Lint (changed scope)
@@ -293,6 +315,45 @@ jobs:
         run: |
           echo "Executing shard ${{ matrix.shard_index }} of 2"
           pnpm turbo run test:integration --filter='@influencerai/api'
+
+  e2e-smoke:
+    name: E2E smoke (PR)
+    needs:
+      - lint
+      - unit-tests
+      - integration-tests
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/e2e-puppeteer.yml
+    with:
+      suite: smoke
+    secrets: inherit
+
+  e2e-full:
+    name: E2E full (main)
+    needs:
+      - lint
+      - unit-tests
+      - integration-tests
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/e2e-puppeteer.yml
+    with:
+      suite: full
+    secrets: inherit
+
+  verify-backlog:
+    name: Verify backlog issues
+    needs: prepare
+    if: needs.prepare.outputs.backlog_changed == 'true'
+    uses: ./.github/workflows/verify-backlog-issues.yml
+    secrets: inherit
+
+  sync-backlog:
+    name: Sync backlog issues
+    needs:
+      - verify-backlog
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.prepare.outputs.backlog_changed == 'true'
+    uses: ./.github/workflows/sync-backlog-issues.yml
+    secrets: inherit
 
   docker-build:
     name: Build Docker images

--- a/.github/workflows/e2e-puppeteer.yml
+++ b/.github/workflows/e2e-puppeteer.yml
@@ -1,10 +1,12 @@
 name: E2E - Puppeteer MCV
 
 on:
-  pull_request:
-    branches: [develop, main]
-  push:
-    branches: [main]
+  workflow_call:
+    inputs:
+      suite:
+        description: 'Suite da eseguire (smoke|full)'
+        required: false
+        type: string
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
@@ -18,7 +20,8 @@ jobs:
   smoke:
     if: >
       github.event_name == 'pull_request' ||
-      (github.event_name == 'workflow_dispatch' && (github.event.inputs.suite || 'full') == 'smoke')
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.suite || 'full') == 'smoke') ||
+      (github.event_name == 'workflow_call' && (inputs.suite || 'full') == 'smoke')
     name: Smoke e2e
     runs-on: ubuntu-latest
     env:
@@ -91,9 +94,9 @@ jobs:
 
   full:
     if: >
-      github.event_name == 'push' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && (github.event.inputs.suite || 'full') == 'full')
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.suite || 'full') == 'full') ||
+      (github.event_name == 'workflow_call' && (inputs.suite || 'full') == 'full')
     name: Full e2e
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/sync-backlog-issues.yml
+++ b/.github/workflows/sync-backlog-issues.yml
@@ -1,13 +1,7 @@
 name: Sync Backlog Issues
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'backlog/issues.yaml'
-  pull_request:
-    paths:
-      - 'backlog/issues.yaml'
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/verify-backlog-issues.yml
+++ b/.github/workflows/verify-backlog-issues.yml
@@ -1,13 +1,7 @@
 name: Verify Backlog Issues
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'backlog/issues.yaml'
-  pull_request:
-    paths:
-      - 'backlog/issues.yaml'
+  workflow_call:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- convert ancillary workflows to reusable workflow_call definitions so they no longer trigger independently on push/PR
- extend the main CI workflow to detect backlog changes and invoke the reusable verification/sync logic only when required
- invoke the e2e workflow from CI for PR smoke runs and main branch full runs while keeping schedule/manual triggers available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ee68c39a288320af4dc92f155e906a