### PR TITLE
Add coverage for worker bootstrap dependencies

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -101,7 +101,7 @@ export function createWorkers(deps: WorkerDependencies) {
           priority: 5,
         }),
       uploadTextAssets: async ({ jobIdentifier, caption, script }) => {
-        const s3Client = s3.getClient();
+        const s3Client = s3.getClient(depLogger);
         if (!s3Client) return {};
         const { client, bucket } = s3Client;
         const baseKey = `content-generation/${jobIdentifier}/`;


### PR DESCRIPTION
## Summary
- extend the worker bootstrap suite to verify dependency wiring for content, LoRA, and video queues
- mock BullMQ, http client, and ffmpeg helpers to test ComfyUI configuration and failure handling deterministically
- pass the worker logger into S3 uploads so tests and runtime share the same instrumentation

## Testing
- pnpm exec vitest run

------
https://chatgpt.com/codex/tasks/task_e_68ee6beeec308320b0055ec984edb7f5