### PR TITLE
WORK-03: ensure worker test suite always runs

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint src/**/*.ts --fix",
-    "test": "pnpm run test:unit",
+    "test": "pnpm run test:unit -- --all",
     "test:unit": "node ../../scripts/run-vitest.mjs --config vitest.config.ts"
   },
   "dependencies": {

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -7,6 +7,7 @@ const rootDir = dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   resolve: {
     alias: {
+      '@influencerai/core-schemas': resolve(rootDir, '../../packages/core-schemas/src/index.ts'),
       '@influencerai/sdk': resolve(rootDir, '../../packages/sdk/src/index.ts'),
       '@influencerai/prompts': resolve(rootDir, '../../packages/prompts/src/index.ts'),
     },

--- a/scripts/run-vitest.mjs
+++ b/scripts/run-vitest.mjs
@@ -22,12 +22,27 @@ const packageRelative = normalizePath(relative(repoRoot, packageDir));
 const baseSha = process.env.CI_BASE_SHA || process.env.GITHUB_BASE_SHA || '';
 const headSha = process.env.CI_HEAD_SHA || 'HEAD';
 const selectionMode = (process.env.VITEST_SELECTION_MODE || 'auto').toLowerCase();
+
+const FORCE_ALL_FLAGS = new Set(['--all', '--force-all']);
+const rawForwardArgs = process.argv.slice(2);
+const sanitizedArgs = [];
+let cliForceAll = false;
+
+for (const arg of rawForwardArgs) {
+  if (FORCE_ALL_FLAGS.has(String(arg))) {
+    cliForceAll = true;
+    continue;
+  }
+  sanitizedArgs.push(arg);
+}
+
+const forwardArgs = sanitizedArgs;
+
 const forceAll =
+  cliForceAll ||
   process.env.VITEST_FORCE_ALL === '1' ||
   process.env.VITEST_FORCE_ALL === 'true' ||
   selectionMode === 'off';
-
-const forwardArgs = process.argv.slice(2);
 const shardIndexRaw = process.env.VITEST_SHARD_INDEX;
 const totalShardsRaw = process.env.VITEST_TOTAL_SHARDS;
 const shardIndex = shardIndexRaw ? Number(shardIndexRaw) : NaN;


### PR DESCRIPTION
## Summary
- add a workspace alias for `@influencerai/core-schemas` in the worker Vitest config
- extend the shared Vitest runner with a `--all` flag to force a full run
- update the worker `test` script to always execute the full suite using the new flag

## Testing
- pnpm test (from apps/worker)


------
https://chatgpt.com/codex/tasks/task_e_68efd355295083209bfa2d0810b02b58