### PR TITLE
feat: add backlog tooling workflows

### DIFF
--- a/.github/workflows/e2e-puppeteer.yml
+++ b/.github/workflows/e2e-puppeteer.yml
@@ -1,0 +1,83 @@
+name: E2E Puppeteer
+
+on:
+  workflow_call:
+    inputs:
+      suite:
+        description: 'Test suite to run (smoke or full)'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: 'Test suite to run'
+        required: false
+        default: smoke
+        type: choice
+        options:
+          - smoke
+          - full
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CI: 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
+        with:
+          version: '10.17.1'
+
+      - name: Resolve pnpm store
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm -w install --frozen-lockfile --prefer-offline
+
+      - name: Start E2E server
+        run: |
+          pnpm --filter @influencerai/e2e run e2e:server &
+          echo $! > server.pid
+
+      - name: Wait for server
+        run: pnpm exec wait-on http://127.0.0.1:5173/healthz
+
+      - name: Run E2E tests
+        env:
+          E2E_BASE: http://127.0.0.1:5173
+          TEST_SUITE: ${{ inputs.suite || github.event.inputs.suite || 'smoke' }}
+        run: |
+          if [ "$TEST_SUITE" = "full" ]; then
+            pnpm --filter @influencerai/e2e run e2e:test
+          else
+            pnpm --filter @influencerai/e2e run e2e:test:smoke
+          fi
+
+      - name: Stop server
+        if: always()
+        run: |
+          if [ -f server.pid ]; then
+            kill $(cat server.pid) || true
+          fi

--- a/.github/workflows/sync-backlog-issues.yml
+++ b/.github/workflows/sync-backlog-issues.yml
@@ -1,0 +1,39 @@
+name: Sync Backlog Issues
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - backlog/issues.yaml
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
+        with:
+          version: '10.17.1'
+
+      - name: Install dependencies
+        run: pnpm -w install --frozen-lockfile --prefer-offline
+
+      - name: Sync backlog with GitHub issues
+        env:
+          GH_PAT_READ: ${{ secrets.GH_PAT_READ }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm --filter @influencerai/backlog-tools exec tsx src/bin/sync.ts

--- a/.github/workflows/verify-backlog-issues.yml
+++ b/.github/workflows/verify-backlog-issues.yml
@@ -1,0 +1,42 @@
+name: Verify Backlog Issues
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - backlog/issues.yaml
+  pull_request:
+    paths:
+      - backlog/issues.yaml
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
+        with:
+          version: '10.17.1'
+
+      - name: Install dependencies
+        run: pnpm -w install --frozen-lockfile --prefer-offline
+
+      - name: Verify backlog issues
+        env:
+          GH_PAT_READ: ${{ secrets.GH_PAT_READ }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm --filter @influencerai/backlog-tools exec tsx src/bin/verify.ts

--- a/packages/backlog-tools/package.json
+++ b/packages/backlog-tools/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@influencerai/backlog-tools",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --config ../../.eslintrc.json --resolve-plugins-relative-to . \"src/**/*.{ts,tsx}\"",
+    "test:unit": "vitest run"
+  },
+  "dependencies": {
+    "yaml": "^2.8.1"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^8.45.0",
+    "@typescript-eslint/parser": "^8.45.0"
+  }
+}

--- a/packages/backlog-tools/src/__tests__/backlog.spec.ts
+++ b/packages/backlog-tools/src/__tests__/backlog.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { isDodComplete, parseBacklog } from '../backlog.js';
+
+const SAMPLE_YAML = `
+issues:
+  - code: TEST-01
+    title: 'TEST-01: Example'
+    body: |-
+      ### DoD
+      - [x] done
+      - [x] also done
+    labels: ['priority:P1']
+  - title: 'TEST-02: Missing code derives from title'
+    body: |-
+      ### DoD
+      - [ ] pending
+`;
+
+describe('parseBacklog', () => {
+  it('normalises backlog issues and detects DoD completion', () => {
+    const issues = parseBacklog(SAMPLE_YAML);
+    expect(issues).toHaveLength(2);
+    expect(issues[0]).toEqual(
+      expect.objectContaining({
+        code: 'TEST-01',
+        title: 'TEST-01: Example',
+        dodComplete: true,
+        labels: ['priority:P1']
+      })
+    );
+    expect(issues[1]).toEqual(
+      expect.objectContaining({
+        code: 'TEST-02',
+        dodComplete: false
+      })
+    );
+  });
+});
+
+describe('isDodComplete', () => {
+  it('returns true when all checkboxes are checked', () => {
+    const body = '- [x] done\n- [X] done again';
+    expect(isDodComplete(body)).toBe(true);
+  });
+
+  it('returns false when there are unchecked items', () => {
+    const body = '- [x] done\n- [ ] pending';
+    expect(isDodComplete(body)).toBe(false);
+  });
+
+  it('returns false when no checkboxes are present', () => {
+    expect(isDodComplete('No tasks')).toBe(false);
+  });
+});

--- a/packages/backlog-tools/src/__tests__/sync.spec.ts
+++ b/packages/backlog-tools/src/__tests__/sync.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { syncBacklog } from '../sync.js';
+import type { BacklogIssue, GithubGateway, GithubIssueReference } from '../types.js';
+
+const ISSUE: BacklogIssue = {
+  code: 'SYNC-01',
+  title: 'SYNC-01: Example',
+  body: 'line1\n- [x] done',
+  labels: ['priority:P1', 'area:web'],
+  assignees: [],
+  milestone: undefined,
+  dodComplete: true
+};
+
+describe('syncBacklog', () => {
+  it('creates missing labels and updates issues when content differs', async () => {
+    const github: GithubGateway = {
+      ensureLabels: vi.fn().mockResolvedValue(undefined),
+      findIssueByCode: vi.fn().mockResolvedValue<GithubIssueReference>({
+        number: 42,
+        title: 'SYNC-01: Example',
+        state: 'closed',
+        body: 'line1\n- [ ] todo',
+        labels: ['priority:P1'],
+        htmlUrl: 'https://example.com/42'
+      }),
+      updateIssue: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const result = await syncBacklog({ issues: [ISSUE], github });
+    expect(github.ensureLabels).toHaveBeenCalledWith(['priority:P1', 'area:web']);
+    expect(github.updateIssue).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({
+        labels: ISSUE.labels,
+        body: ISSUE.body
+      })
+    );
+    expect(result.updated).toBe(1);
+    expect(result.unchanged).toBe(0);
+    expect(result.missing).toHaveLength(0);
+  });
+
+  it('marks issues as missing when not found', async () => {
+    const github: GithubGateway = {
+      ensureLabels: vi.fn().mockResolvedValue(undefined),
+      findIssueByCode: vi.fn().mockResolvedValue(null),
+      updateIssue: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const result = await syncBacklog({ issues: [ISSUE], github });
+    expect(result.missing).toEqual([ISSUE]);
+    expect(result.updated).toBe(0);
+    expect(result.unchanged).toBe(0);
+  });
+
+  it('avoids unnecessary updates when issue already matches', async () => {
+    const github: GithubGateway = {
+      ensureLabels: vi.fn().mockResolvedValue(undefined),
+      findIssueByCode: vi.fn().mockResolvedValue<GithubIssueReference>({
+        number: 7,
+        title: ISSUE.title,
+        state: 'closed',
+        body: ISSUE.body,
+        labels: ISSUE.labels,
+        htmlUrl: 'https://example.com/7'
+      }),
+      updateIssue: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const result = await syncBacklog({ issues: [ISSUE], github });
+    expect(github.updateIssue).not.toHaveBeenCalled();
+    expect(result.updated).toBe(0);
+    expect(result.unchanged).toBe(1);
+  });
+});

--- a/packages/backlog-tools/src/__tests__/verify.spec.ts
+++ b/packages/backlog-tools/src/__tests__/verify.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import { verifyBacklog } from '../verify.js';
+import type { BacklogIssue, GithubGateway } from '../types.js';
+
+const BASE_ISSUES: BacklogIssue[] = [
+  {
+    code: 'TEST-01',
+    title: 'TEST-01: Completed',
+    body: '- [x] done',
+    labels: [],
+    assignees: [],
+    milestone: undefined,
+    dodComplete: true
+  },
+  {
+    code: 'TEST-02',
+    title: 'TEST-02: Not complete',
+    body: '- [ ] pending',
+    labels: [],
+    assignees: [],
+    milestone: undefined,
+    dodComplete: false
+  }
+];
+
+describe('verifyBacklog', () => {
+  it('skips issues without completed DoD', async () => {
+    const github: Pick<GithubGateway, 'findIssueByCode'> = {
+      findIssueByCode: vi.fn().mockResolvedValue({
+        number: 1,
+        title: 'TEST-01: Completed',
+        state: 'closed',
+        body: '',
+        labels: [],
+        htmlUrl: 'https://example.com/1'
+      })
+    };
+
+    const result = await verifyBacklog({ issues: BASE_ISSUES, github });
+    expect(result.checked).toBe(1);
+    expect(result.mismatches).toHaveLength(0);
+    expect(github.findIssueByCode).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports issues that are still open on GitHub', async () => {
+    const github: Pick<GithubGateway, 'findIssueByCode'> = {
+      findIssueByCode: vi.fn().mockResolvedValue({
+        number: 10,
+        title: 'TEST-01: Completed',
+        state: 'open',
+        body: '',
+        labels: [],
+        htmlUrl: 'https://example.com/10'
+      })
+    };
+
+    const result = await verifyBacklog({ issues: BASE_ISSUES, github });
+    expect(result.mismatches).toEqual([
+      {
+        code: 'TEST-01',
+        title: 'TEST-01: Completed',
+        reason: 'Issue still open on GitHub',
+        issueUrl: 'https://example.com/10'
+      }
+    ]);
+  });
+
+  it('reports missing GitHub issues', async () => {
+    const github: Pick<GithubGateway, 'findIssueByCode'> = {
+      findIssueByCode: vi.fn().mockResolvedValue(null)
+    };
+
+    const result = await verifyBacklog({ issues: BASE_ISSUES, github });
+    expect(result.mismatches).toEqual([
+      {
+        code: 'TEST-01',
+        title: 'TEST-01: Completed',
+        reason: 'Issue not found on GitHub'
+      }
+    ]);
+  });
+});

--- a/packages/backlog-tools/src/backlog.ts
+++ b/packages/backlog-tools/src/backlog.ts
@@ -1,0 +1,134 @@
+import { readFile } from 'node:fs/promises';
+import { parse } from 'yaml';
+import type { BacklogIssue } from './types.js';
+
+interface RawBacklogIssue {
+  readonly code?: unknown;
+  readonly title?: unknown;
+  readonly body?: unknown;
+  readonly labels?: unknown;
+  readonly assignees?: unknown;
+  readonly milestone?: unknown;
+}
+
+interface RawBacklogFile {
+  readonly issues?: unknown;
+}
+
+const CHECKBOX_PATTERN = /-\s*\[(?<status>[ xX])\]/g;
+
+export function isDodComplete(body: string): boolean {
+  const matches = Array.from(body.matchAll(CHECKBOX_PATTERN));
+  if (matches.length === 0) {
+    return false;
+  }
+
+  return matches.every((match) => {
+    const status = match.groups?.status ?? '';
+    return status.toLowerCase() === 'x';
+  });
+}
+
+function normaliseBody(value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new Error('Backlog issue body must be a string');
+  }
+
+  return value.replace(/\r\n/g, '\n');
+}
+
+function normaliseTitle(value: unknown): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error('Backlog issue title must be a non-empty string');
+  }
+
+  return value.trim();
+}
+
+function deriveCode(issue: RawBacklogIssue): string {
+  if (typeof issue.code === 'string' && issue.code.trim() !== '') {
+    return issue.code.trim();
+  }
+
+  if (typeof issue.title === 'string') {
+    const code = issue.title.split(':', 1)[0]?.trim();
+    if (code) {
+      return code;
+    }
+  }
+
+  throw new Error('Backlog issue is missing a code');
+}
+
+function normaliseLabels(value: unknown): string[] {
+  if (value == null) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error('Backlog issue labels must be an array');
+  }
+
+  return value.filter((item): item is string => typeof item === 'string' && item.trim() !== '').map((item) => item.trim());
+}
+
+function normaliseAssignees(value: unknown): string[] {
+  if (value == null) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error('Backlog issue assignees must be an array');
+  }
+
+  return value.filter((item): item is string => typeof item === 'string' && item.trim() !== '').map((item) => item.trim());
+}
+
+function normaliseMilestone(value: unknown): string | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error('Backlog issue milestone must be a non-empty string if provided');
+  }
+
+  return value.trim();
+}
+
+export async function loadBacklogIssues(backlogPath: string): Promise<BacklogIssue[]> {
+  const content = await readFile(backlogPath, 'utf8');
+  return parseBacklog(content);
+}
+
+export function parseBacklog(yamlContent: string): BacklogIssue[] {
+  const document = parse(yamlContent) as RawBacklogFile;
+  const { issues } = document;
+
+  if (!Array.isArray(issues)) {
+    throw new Error("Backlog file must contain an 'issues' array");
+  }
+
+  return issues.map((rawIssue, index) => normaliseIssue(rawIssue, index));
+}
+
+function normaliseIssue(rawIssue: unknown, index: number): BacklogIssue {
+  if (rawIssue == null || typeof rawIssue !== 'object') {
+    throw new Error(`Issue at index ${index} must be an object`);
+  }
+
+  const candidate = rawIssue as RawBacklogIssue;
+  const title = normaliseTitle(candidate.title);
+  const body = normaliseBody(candidate.body);
+  const issue: BacklogIssue = {
+    code: deriveCode(candidate),
+    title,
+    body,
+    labels: normaliseLabels(candidate.labels),
+    assignees: normaliseAssignees(candidate.assignees),
+    milestone: normaliseMilestone(candidate.milestone),
+    dodComplete: isDodComplete(body)
+  };
+
+  return issue;
+}

--- a/packages/backlog-tools/src/bin/sync.ts
+++ b/packages/backlog-tools/src/bin/sync.ts
@@ -1,0 +1,36 @@
+/* eslint-disable no-console */
+import { loadBacklogIssues } from '../backlog.js';
+import { GithubClient } from '../github.js';
+import { syncBacklog } from '../sync.js';
+
+async function main(): Promise<void> {
+  const backlogPath = process.env.BACKLOG_FILE ?? 'backlog/issues.yaml';
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!repository) {
+    throw new Error('GITHUB_REPOSITORY is required');
+  }
+
+  const token = process.env.GH_PAT_READ || process.env.GITHUB_TOKEN;
+  const allowMissing = process.env.BACKLOG_SYNC_ALLOW_MISSING === '1';
+  const issues = await loadBacklogIssues(backlogPath);
+  const github = new GithubClient({ repository, token: token || undefined });
+
+  const result = await syncBacklog({ issues, github });
+  console.log(`Updated ${result.updated} issues; ${result.unchanged} already in sync.`);
+
+  if (result.missing.length > 0) {
+    console.error('Missing GitHub issues for backlog entries:');
+    for (const issue of result.missing) {
+      console.error(`- ${issue.code} (${issue.title})`);
+    }
+
+    if (!allowMissing) {
+      throw new Error(`${result.missing.length} backlog issues are missing on GitHub.`);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/backlog-tools/src/bin/verify.ts
+++ b/packages/backlog-tools/src/bin/verify.ts
@@ -1,0 +1,40 @@
+/* eslint-disable no-console */
+import { loadBacklogIssues } from '../backlog.js';
+import { GithubClient } from '../github.js';
+import { verifyBacklog } from '../verify.js';
+
+async function main(): Promise<void> {
+  const backlogPath = process.env.BACKLOG_FILE ?? 'backlog/issues.yaml';
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!repository) {
+    throw new Error('GITHUB_REPOSITORY is required');
+  }
+
+  const token = process.env.GH_PAT_READ || process.env.GITHUB_TOKEN;
+  const issues = await loadBacklogIssues(backlogPath);
+  const github = new GithubClient({ repository, token: token || undefined });
+
+  const result = await verifyBacklog({ issues, github });
+
+  if (result.checked === 0) {
+    console.log('No completed DoD items to verify.');
+    return;
+  }
+
+  if (result.mismatches.length === 0) {
+    console.log(`All ${result.checked} completed issues are closed on GitHub.`);
+    return;
+  }
+
+  console.error('Detected backlog / GitHub mismatches:');
+  for (const mismatch of result.mismatches) {
+    console.error(`- ${mismatch.code}: ${mismatch.reason}${mismatch.issueUrl ? ` (${mismatch.issueUrl})` : ''}`);
+  }
+
+  throw new Error(`${result.mismatches.length} completed issues are not closed on GitHub.`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/backlog-tools/src/github.ts
+++ b/packages/backlog-tools/src/github.ts
@@ -1,0 +1,215 @@
+import type { GithubGateway, GithubIssueReference } from './types.js';
+
+interface GithubClientOptions {
+  readonly repository: string;
+  readonly token?: string;
+  readonly fetchImpl?: typeof fetch;
+  readonly defaultLabelColor?: string;
+}
+
+interface GithubLabel {
+  readonly name: string;
+  readonly color?: string;
+}
+
+interface GithubIssueResponse {
+  readonly number: number;
+  readonly title: string;
+  readonly state: 'open' | 'closed';
+  readonly body?: string | null;
+  readonly html_url: string;
+  readonly labels?: Array<GithubLabel | string>;
+}
+
+interface GithubSearchResponse {
+  readonly items?: GithubIssueResponse[];
+}
+
+export class GithubClient implements GithubGateway {
+  private readonly owner: string;
+  private readonly repo: string;
+  private readonly token?: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly defaultLabelColor: string;
+  private knownLabels: Set<string> | null = null;
+
+  constructor(options: GithubClientOptions) {
+    const [owner, repo] = options.repository.split('/');
+    if (!owner || !repo) {
+      throw new Error('repository must be in the format <owner>/<repo>');
+    }
+
+    this.owner = owner;
+    this.repo = repo;
+    this.token = options.token;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.defaultLabelColor = options.defaultLabelColor ?? '6f42c1';
+  }
+
+  async findIssueByCode(code: string): Promise<GithubIssueReference | null> {
+    const issue = await this.searchIssue(code);
+    if (!issue) {
+      return null;
+    }
+
+    const labels = (issue.labels ?? []).map((label) =>
+      typeof label === 'string' ? label : label.name
+    );
+
+    return {
+      number: issue.number,
+      title: issue.title,
+      state: issue.state,
+      body: issue.body ?? '',
+      labels,
+      htmlUrl: issue.html_url
+    };
+  }
+
+  async ensureLabels(labels: readonly string[]): Promise<void> {
+    const existing = await this.loadKnownLabels();
+    const missing = labels.filter((label) => !existing.has(label));
+    if (missing.length === 0) {
+      return;
+    }
+
+    for (const label of missing) {
+      await this.createLabel(label);
+      existing.add(label);
+    }
+  }
+
+  async updateIssue(
+    issueNumber: number,
+    update: Partial<Pick<GithubIssueReference, 'body' | 'labels' | 'title'>>
+  ): Promise<void> {
+    const payload: Record<string, unknown> = {};
+    if (typeof update.body === 'string') {
+      payload.body = update.body;
+    }
+
+    if (Array.isArray(update.labels)) {
+      payload.labels = update.labels;
+    }
+
+    if (typeof update.title === 'string') {
+      payload.title = update.title;
+    }
+
+    if (Object.keys(payload).length === 0) {
+      return;
+    }
+
+    const response = await this.request(`/repos/${this.owner}/${this.repo}/issues/${issueNumber}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to update issue #${issueNumber}: ${response.status} ${await response.text()}`);
+    }
+  }
+
+  private async searchIssue(code: string): Promise<GithubIssueResponse | null> {
+    const query = encodeURIComponent(`repo:${this.owner}/${this.repo} is:issue in:title "${code}"`);
+    const response = await this.request(`/search/issues?q=${query}&per_page=5`);
+    if (!response.ok) {
+      throw new Error(`Failed to search issues: ${response.status} ${await response.text()}`);
+    }
+
+    const data = (await response.json()) as GithubSearchResponse;
+    const items = data.items ?? [];
+    const pattern = new RegExp(`\\b${escapeRegExp(code)}\\b`, 'i');
+    const match = items.find((item) => pattern.test(item.title));
+
+    if (!match) {
+      return null;
+    }
+
+    const issueResponse = await this.request(
+      `/repos/${this.owner}/${this.repo}/issues/${match.number}`
+    );
+
+    if (!issueResponse.ok) {
+      throw new Error(`Failed to load issue #${match.number}: ${issueResponse.status} ${await issueResponse.text()}`);
+    }
+
+    return (await issueResponse.json()) as GithubIssueResponse;
+  }
+
+  private async loadKnownLabels(): Promise<Set<string>> {
+    if (this.knownLabels) {
+      return this.knownLabels;
+    }
+
+    const labels = new Set<string>();
+    let page = 1;
+    while (true) {
+      const response = await this.request(
+        `/repos/${this.owner}/${this.repo}/labels?per_page=100&page=${page}`
+      );
+
+      if (!response.ok) {
+        throw new Error(`Failed to list labels: ${response.status} ${await response.text()}`);
+      }
+
+      const data = (await response.json()) as GithubLabel[];
+      if (data.length === 0) {
+        break;
+      }
+
+      for (const label of data) {
+        if (label.name) {
+          labels.add(label.name);
+        }
+      }
+
+      page += 1;
+    }
+
+    this.knownLabels = labels;
+    return labels;
+  }
+
+  private async createLabel(name: string): Promise<void> {
+    const payload = {
+      name,
+      color: this.defaultLabelColor
+    };
+
+    const response = await this.request(`/repos/${this.owner}/${this.repo}/labels`, {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok && response.status !== 422) {
+      throw new Error(`Failed to create label ${name}: ${response.status} ${await response.text()}`);
+    }
+  }
+
+  private async request(pathname: string, init?: RequestInit): Promise<Response> {
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'influencerai-backlog-tools'
+    };
+
+    if (this.token) {
+      headers.Authorization = `Bearer ${this.token}`;
+    }
+
+    const response = await this.fetchImpl(`https://api.github.com${pathname}`, {
+      ...init,
+      headers: {
+        ...headers,
+        ...(init?.headers ?? {})
+      }
+    });
+
+    return response;
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&');
+}

--- a/packages/backlog-tools/src/index.ts
+++ b/packages/backlog-tools/src/index.ts
@@ -1,0 +1,5 @@
+export * from './backlog.js';
+export * from './github.js';
+export * from './sync.js';
+export * from './types.js';
+export * from './verify.js';

--- a/packages/backlog-tools/src/sync.ts
+++ b/packages/backlog-tools/src/sync.ts
@@ -1,0 +1,91 @@
+import type {
+  BacklogIssue,
+  GithubGateway,
+  GithubIssueReference,
+  SyncResult
+} from './types.js';
+
+interface SyncOptions {
+  readonly issues: readonly BacklogIssue[];
+  readonly github: GithubGateway;
+}
+
+export async function syncBacklog(options: SyncOptions): Promise<SyncResult> {
+  const uniqueLabels = new Set<string>();
+  for (const issue of options.issues) {
+    for (const label of issue.labels) {
+      uniqueLabels.add(label);
+    }
+  }
+
+  await options.github.ensureLabels([...uniqueLabels]);
+
+  let updated = 0;
+  let unchanged = 0;
+  const missing: BacklogIssue[] = [];
+
+  for (const issue of options.issues) {
+    const remote = await options.github.findIssueByCode(issue.code);
+    if (!remote) {
+      missing.push(issue);
+      continue;
+    }
+
+    const needsUpdate = determineUpdates(issue, remote);
+    if (!needsUpdate) {
+      unchanged += 1;
+      continue;
+    }
+
+    await options.github.updateIssue(remote.number, needsUpdate);
+    updated += 1;
+  }
+
+  return {
+    updated,
+    unchanged,
+    missing
+  };
+}
+
+function determineUpdates(
+  issue: BacklogIssue,
+  remote: GithubIssueReference
+): Partial<Pick<GithubIssueReference, 'body' | 'labels' | 'title'>> | null {
+  const desiredLabels = [...issue.labels].sort();
+  const remoteLabels = [...remote.labels].sort();
+  const labelsChanged = !areArraysEqual(desiredLabels, remoteLabels);
+  const bodyChanged = normaliseLineEndings(remote.body) !== normaliseLineEndings(issue.body);
+  const titleChanged = remote.title !== issue.title;
+
+  if (!labelsChanged && !bodyChanged && !titleChanged) {
+    return null;
+  }
+
+  const update: Partial<Pick<GithubIssueReference, 'body' | 'labels' | 'title'>> = {};
+  if (labelsChanged) {
+    update.labels = issue.labels;
+  }
+
+  if (bodyChanged) {
+    update.body = issue.body;
+  }
+
+  if (titleChanged) {
+    update.title = issue.title;
+  }
+
+  return update;
+}
+
+function normaliseLineEndings(value: string): string {
+  return value.replace(/\r\n/g, '\n');
+}
+
+function areArraysEqual<T>(a: readonly T[], b: readonly T[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  return a.every((value, index) => value === b[index]);
+}

--- a/packages/backlog-tools/src/types.ts
+++ b/packages/backlog-tools/src/types.ts
@@ -1,0 +1,45 @@
+export interface BacklogIssue {
+  readonly code: string;
+  readonly title: string;
+  readonly body: string;
+  readonly labels: readonly string[];
+  readonly assignees: readonly string[];
+  readonly milestone?: string;
+  readonly dodComplete: boolean;
+}
+
+export interface GithubIssueReference {
+  readonly number: number;
+  readonly title: string;
+  readonly state: 'open' | 'closed';
+  readonly body: string;
+  readonly labels: readonly string[];
+  readonly htmlUrl: string;
+}
+
+export interface GithubGateway {
+  findIssueByCode(code: string): Promise<GithubIssueReference | null>;
+  ensureLabels(labels: readonly string[]): Promise<void>;
+  updateIssue(
+    issueNumber: number,
+    update: Partial<Pick<GithubIssueReference, 'body' | 'labels' | 'title'>>
+  ): Promise<void>;
+}
+
+export interface VerificationMismatch {
+  readonly code: string;
+  readonly title: string;
+  readonly reason: string;
+  readonly issueUrl?: string;
+}
+
+export interface VerificationResult {
+  readonly checked: number;
+  readonly mismatches: readonly VerificationMismatch[];
+}
+
+export interface SyncResult {
+  readonly updated: number;
+  readonly unchanged: number;
+  readonly missing: readonly BacklogIssue[];
+}

--- a/packages/backlog-tools/src/verify.ts
+++ b/packages/backlog-tools/src/verify.ts
@@ -1,0 +1,43 @@
+import type { BacklogIssue, GithubGateway, VerificationResult } from './types.js';
+
+interface VerifyOptions {
+  readonly issues: readonly BacklogIssue[];
+  readonly github: Pick<GithubGateway, 'findIssueByCode'>;
+}
+
+export async function verifyBacklog(options: VerifyOptions): Promise<VerificationResult> {
+  const mismatches = [];
+  let checked = 0;
+
+  for (const issue of options.issues) {
+    if (!issue.dodComplete) {
+      continue;
+    }
+
+    checked += 1;
+    const remote = await options.github.findIssueByCode(issue.code);
+
+    if (!remote) {
+      mismatches.push({
+        code: issue.code,
+        title: issue.title,
+        reason: 'Issue not found on GitHub'
+      });
+      continue;
+    }
+
+    if (remote.state !== 'closed') {
+      mismatches.push({
+        code: issue.code,
+        title: issue.title,
+        reason: 'Issue still open on GitHub',
+        issueUrl: remote.htmlUrl
+      });
+    }
+  }
+
+  return {
+    checked,
+    mismatches
+  };
+}

--- a/packages/backlog-tools/tsconfig.json
+++ b/packages/backlog-tools/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/backlog-tools/vitest.config.ts
+++ b/packages/backlog-tools/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    coverage: {
+      enabled: false
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,7 +225,7 @@ importers:
         version: 2.6.0
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.18(tsx@4.20.6))
+        version: 1.0.7(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.1))
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -277,7 +277,7 @@ importers:
         version: 0.9.5
       tailwindcss:
         specifier: ^3.4.16
-        version: 3.4.18(tsx@4.20.6)
+        version: 3.4.18(tsx@4.20.6)(yaml@2.8.1)
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0)
@@ -342,6 +342,19 @@ importers:
       vitest:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0)
+
+  packages/backlog-tools:
+    dependencies:
+      yaml:
+        specifier: ^2.8.1
+        version: 2.8.1
+    devDependencies:
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.45.0
+        version: 8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.45.0
+        version: 8.45.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
 
   packages/core-schemas:
     dependencies:
@@ -7041,6 +7054,11 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yaml@2.8.1:
+    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -9777,7 +9795,7 @@ snapshots:
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.2
+      semver: 7.7.3
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -12504,7 +12522,7 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.7.2
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13398,13 +13416,14 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.6
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.6):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.6
       tsx: 4.20.6
+      yaml: 2.8.1
 
   postcss-nested@6.2.0(postcss@8.5.6):
     dependencies:
@@ -14210,11 +14229,11 @@ snapshots:
 
   tailwind-merge@2.6.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.18(tsx@4.20.6)):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
-      tailwindcss: 3.4.18(tsx@4.20.6)
+      tailwindcss: 3.4.18(tsx@4.20.6)(yaml@2.8.1)
 
-  tailwindcss@3.4.18(tsx@4.20.6):
+  tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -14233,7 +14252,7 @@ snapshots:
       postcss: 8.5.6
       postcss-import: 15.1.0(postcss@8.5.6)
       postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.6)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.6)(yaml@2.8.1)
       postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
@@ -15017,6 +15036,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
+
+  yaml@2.8.1: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Summary
- add a reusable Puppeteer E2E workflow that caches installs, boots the mock server, and runs smoke or full suites on demand
- provide backlog verification and sync workflows that execute new @influencerai/backlog-tools scripts with GitHub PAT support
- introduce the @influencerai/backlog-tools package with backlog parsing, GitHub client logic, CLI entry points, and unit tests

## Testing
- pnpm --filter @influencerai/backlog-tools test:unit

------
https://chatgpt.com/codex/tasks/task_e_68efd13df4c08320b3c10db04fd35d74