### PR TITLE
chore: sync backlog DoD for closed issues

### DIFF
--- a/backlog/issues.yaml
+++ b/backlog/issues.yaml
@@ -585,13 +585,13 @@ issues:
 
     ### DoD
 
-    - [ ] setupTests.ts contiene import di @testing-library/jest-dom.
+    - [x] setupTests.ts contiene import di @testing-library/jest-dom.
 
-    - [ ] Test esistenti in src/__tests__/home.test.tsx passano.
+    - [x] Test esistenti in src/__tests__/home.test.tsx passano.
 
-    - [ ] Matcher Jest-DOM funzionanti.
+    - [x] Matcher Jest-DOM funzionanti.
 
-    - [ ] Script test e test:watch configurati.
+    - [x] Script test e test:watch configurati.
 
     '
   labels:
@@ -703,13 +703,13 @@ issues:
 
     ### DoD
 
-    - [ ] Metodi listJobs, updateJob, listDatasets, createDataset, getContentPlan.
+    - [x] Metodi listJobs, updateJob, listDatasets, createDataset, getContentPlan.
 
-    - [ ] Gestione errori HTTP con traduzione in eccezioni typed.
+    - [x] Gestione errori HTTP con traduzione in eccezioni typed.
 
-    - [ ] Test unitari con msw o fetch mock.
+    - [x] Test unitari con msw o fetch mock.
 
-    - [ ] Pubblicazione interna (pnpm build) per consumo web/worker.
+    - [x] Pubblicazione interna (pnpm build) per consumo web/worker.
 
 
     ### Dipendenze
@@ -1085,11 +1085,12 @@ issues:
   impact: High
   estimate: M
   code: CODE-04
-  - title: 'WEB-07: Implementare l\'interfaccia progettata su Lovable.dev'
+
+- title: 'WEB-07: Implementare l''interfaccia progettata su Lovable.dev'
   body: '### Contesto
 
-    È stata definita un\'interfaccia utente su Lovable.dev (mockup/prototipo). Occorre
-    implementarla nell\'app web allineando layout, componenti e routing, mantenendo
+    È stata definita un''interfaccia utente su Lovable.dev (mockup/prototipo). Occorre
+    implementarla nell''app web allineando layout, componenti e routing, mantenendo
     coerenza con il design system (shadcn/ui) e le API esistenti.
 
 

--- a/packages/backlog-tools/src/__tests__/closed-issues.spec.ts
+++ b/packages/backlog-tools/src/__tests__/closed-issues.spec.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { parseBacklog } from '../backlog.js';
+
+function loadBacklogIssues() {
+  const content = readFileSync(new URL('../../../../backlog/issues.yaml', import.meta.url), 'utf8');
+  return parseBacklog(content);
+}
+
+describe('backlog closed issues', () => {
+  it('marks WEB-03 and SDK-01 as DoD complete', () => {
+    const issues = loadBacklogIssues();
+    const byCode = new Map(issues.map((issue) => [issue.code, issue]));
+
+    expect(byCode.get('WEB-03')?.dodComplete).toBe(true);
+    expect(byCode.get('SDK-01')?.dodComplete).toBe(true);
+  });
+});

--- a/packages/backlog-tools/vitest.config.ts
+++ b/packages/backlog-tools/vitest.config.ts
@@ -4,6 +4,13 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['src/**/*.spec.ts'],
+    deps: {
+      optimizer: {
+        ssr: {
+          exclude: ['yaml']
+        }
+      }
+    },
     coverage: {
       enabled: false
     }


### PR DESCRIPTION
## Summary
- mark the Definition of Done items for WEB-03 and SDK-01 as complete in the backlog data
- fix the WEB-07 backlog entry formatting and add a regression test covering closed issues
- configure the backlog-tools Vitest setup to resolve the yaml dependency during tests

## Testing
- pnpm --filter @influencerai/backlog-tools test:unit

------
https://chatgpt.com/codex/tasks/task_e_68efda62b178832081598a77ea24ea26