### PR TITLE
fix(backlog-tools): ensure yaml parser availability

### DIFF
--- a/packages/backlog-tools/package.json
+++ b/packages/backlog-tools/package.json
@@ -8,6 +8,7 @@
     "test:unit": "vitest run"
   },
   "dependencies": {
+    "js-yaml": "^4.1.0",
     "yaml": "^2.8.1"
   },
   "devDependencies": {

--- a/packages/backlog-tools/src/__tests__/yaml-parser.spec.ts
+++ b/packages/backlog-tools/src/__tests__/yaml-parser.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { ModuleResolver } from '../yaml-parser.js';
+import { createYamlParser } from '../yaml-parser.js';
+
+describe('createYamlParser', () => {
+  it('prefers the yaml package when available', () => {
+    const parse = createYamlParser(new StubResolver({
+      yaml: { parse: (content: string) => ({ parsed: content }) }
+    }));
+
+    expect(parse('content')).toEqual({ parsed: 'content' });
+  });
+
+  it('falls back to js-yaml when yaml is unavailable', () => {
+    const parse = createYamlParser(
+      new StubResolver({ 'js-yaml': { load: (content: string) => ({ loaded: content }) } })
+    );
+
+    expect(parse('content')).toEqual({ loaded: 'content' });
+  });
+
+  it('throws a descriptive error when no parser is available', () => {
+    const resolver = new StubResolver({});
+
+    expect(() => createYamlParser(resolver)).toThrowError(
+      /Install either "yaml" or "js-yaml" to continue/
+    );
+  });
+});
+
+class StubResolver implements ModuleResolver {
+  private readonly modules: Map<string, unknown>;
+
+  constructor(modules: Record<string, unknown>) {
+    this.modules = new Map(Object.entries(modules));
+  }
+
+  has(specifier: string): boolean {
+    return this.modules.has(specifier);
+  }
+
+  import<T>(specifier: string): T {
+    if (!this.modules.has(specifier)) {
+      throw new Error(`Module ${specifier} not found in stub resolver`);
+    }
+
+    return this.modules.get(specifier) as T;
+  }
+}

--- a/packages/backlog-tools/src/backlog.ts
+++ b/packages/backlog-tools/src/backlog.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { parse } from 'yaml';
+import { createYamlParser } from './yaml-parser.js';
 import type { BacklogIssue } from './types.js';
 
 interface RawBacklogIssue {
@@ -101,8 +101,10 @@ export async function loadBacklogIssues(backlogPath: string): Promise<BacklogIss
   return parseBacklog(content);
 }
 
+const parseYaml = createYamlParser();
+
 export function parseBacklog(yamlContent: string): BacklogIssue[] {
-  const document = parse(yamlContent) as RawBacklogFile;
+  const document = parseYaml(yamlContent) as RawBacklogFile;
   const { issues } = document;
 
   if (!Array.isArray(issues)) {

--- a/packages/backlog-tools/src/yaml-parser.ts
+++ b/packages/backlog-tools/src/yaml-parser.ts
@@ -1,0 +1,55 @@
+import { createRequire } from 'node:module';
+
+export interface ModuleResolver {
+  has(specifier: string): boolean;
+  import<T>(specifier: string): T;
+}
+
+type ParseFunction = (content: string) => unknown;
+
+const defaultResolver = createDefaultResolver();
+
+export function createYamlParser(resolver: ModuleResolver = defaultResolver): ParseFunction {
+  if (resolver.has('yaml')) {
+    const library = resolver.import<typeof import('yaml')>('yaml');
+    return library.parse;
+  }
+
+  if (resolver.has('js-yaml')) {
+    const library = resolver.import<typeof import('js-yaml')>('js-yaml');
+    return (content) => library.load(content);
+  }
+
+  throw new Error('No YAML parser available. Install either "yaml" or "js-yaml" to continue.');
+}
+
+function createDefaultResolver(): ModuleResolver {
+  const require = createRequire(import.meta.url);
+
+  return {
+    has(specifier: string): boolean {
+      try {
+        require.resolve(specifier);
+        return true;
+      } catch (error) {
+        if (isModuleNotFoundError(error)) {
+          return false;
+        }
+
+        throw error;
+      }
+    },
+    import<T>(specifier: string): T {
+      return require(specifier) as T;
+    }
+  } satisfies ModuleResolver;
+}
+
+function isModuleNotFoundError(error: unknown): error is NodeJS.ErrnoException {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      (error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND'
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,6 +345,9 @@ importers:
 
   packages/backlog-tools:
     dependencies:
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       yaml:
         specifier: ^2.8.1
         version: 2.8.1


### PR DESCRIPTION
## Summary
- add a YAML parser factory that prefers the `yaml` package and falls back to `js-yaml`
- use the new factory in backlog parsing and extend unit coverage for the parser selection
- declare `js-yaml` as a direct dependency for backlog tools and refresh the lockfile

## Testing
- pnpm --filter @influencerai/backlog-tools test:unit

------
https://chatgpt.com/codex/tasks/task_e_68efdd384eac832081151e0f8830c337