### PR TITLE
fix(ci): remove unsupported minio command in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,6 @@ jobs:
           --health-interval 15s
           --health-timeout 10s
           --health-retries 10
-        command: server /data --console-address ":9001"
     env:
       CI: 'true'
       CI_BASE_SHA: ${{ needs.prepare.outputs.base_sha }}


### PR DESCRIPTION
## Summary
- remove the unsupported minio service command from the CI workflow to resolve the workflow syntax error

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68efe013c5dc8320bacf33f6748e67b0