### PR TITLE
fix: grant issues read permission to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  issues: read
+
 jobs:
   prepare:
     name: Prepare diff context


### PR DESCRIPTION
## Summary
- add explicit issues: read permission to the CI workflow so reusable backlog verification can run

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eff2d283b88320a4fa87425373ba84