### PR TITLE
fix: improve type safety for json payloads and fetch utilities

### DIFF
--- a/apps/api/src/lib/json.spec.ts
+++ b/apps/api/src/lib/json.spec.ts
@@ -1,0 +1,39 @@
+import { Prisma } from '@prisma/client';
+import { toInputJson, toInputJsonObject } from './json';
+
+type IsAny<T> = 0 extends (1 & T) ? true : false;
+
+describe('toInputJson helpers', () => {
+  it('converts supported primitives without modification', () => {
+    expect(toInputJson('value')).toBe('value');
+    expect(toInputJson(42)).toBe(42);
+    expect(toInputJson(true)).toBe(true);
+    expect(toInputJson(null)).toBeNull();
+  });
+
+  it('converts dates and nested structures to Prisma-compatible JSON', () => {
+    const date = new Date('2024-01-01T00:00:00.000Z');
+    const result = toInputJson({ foo: date, nested: { arr: [1, 'two'] } });
+
+    expect(result).toEqual({
+      foo: date.toISOString(),
+      nested: { arr: [1, 'two'] },
+    });
+  });
+
+  it('enforces Prisma.InputJsonValue typings', () => {
+    const value = toInputJson({ count: 1 });
+    const ensureAssignable: Prisma.InputJsonValue = value;
+    void ensureAssignable;
+    type ValueIsAny = IsAny<typeof value>;
+    const ensureNotAny: ValueIsAny extends true ? never : true = true;
+    void ensureNotAny;
+  });
+
+  it('builds JsonObject structures', () => {
+    const obj = toInputJsonObject({ name: 'demo', flag: false });
+    const ensureAssignable: Prisma.JsonObject = obj;
+    void ensureAssignable;
+    expect(obj).toEqual({ name: 'demo', flag: false });
+  });
+});

--- a/apps/api/src/lib/json.ts
+++ b/apps/api/src/lib/json.ts
@@ -1,0 +1,33 @@
+import { Prisma } from '@prisma/client';
+
+export function toInputJson(value: unknown): Prisma.InputJsonValue {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => toInputJson(item)) as Prisma.JsonArray;
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    return toInputJsonObject(value as Record<string, unknown>);
+  }
+
+  return null;
+}
+
+export function toInputJsonObject(value: Record<string, unknown>): Prisma.JsonObject {
+  return Object.entries(value).reduce<Prisma.JsonObject>((acc, [key, entry]) => {
+    acc[key] = toInputJson(entry);
+    return acc;
+  }, {});
+}


### PR DESCRIPTION
## Summary
- add reusable helpers for Prisma-compatible JSON serialization and cover them with tests
- update content plan and job services to use the new helpers and safer Response parsing
- tighten SDK fetch utilities typing and extend unit tests to guard against `any`
- sanitize the e2e setup timer patch to avoid implicit `any`

## Testing
- pnpm --filter "@influencerai/sdk" test:unit
- JEST_FORCE_ALL=1 pnpm --filter "@influencerai/api" test:unit

------
https://chatgpt.com/codex/tasks/task_e_68f010e167008320a0be5b9307877d26