### PR TITLE
feat(sdk): add react query hooks for client

### DIFF
--- a/apps/web/README.dashboard.md
+++ b/apps/web/README.dashboard.md
@@ -27,6 +27,38 @@ Notes:
 - Replace polling with websockets when API supports it.
 - Styles rely on the shared design system primitives documented below.
 
+## SDK React hooks
+
+- Import hooks from `@influencerai/sdk/react` to reuse the HTTP client with TanStack Query.
+- Wrap the application once with `<InfluencerAIProvider baseUrl={process.env.NEXT_PUBLIC_API_BASE_URL}>` inside `src/app/providers.tsx` (after the QueryClient provider).
+- Available hooks mirror the API surface:
+  - `useJobs` / `useJob`
+  - `useCreateJob`
+  - `useQueuesSummary`
+  - `useDatasets` / `useCreateDataset`
+  - `useContentPlan` / `useCreateContentPlan`
+- Mutations automatically invalidate list/detail queries and the queues summary.
+- Hooks accept the same options as their TanStack Query counterparts so you can override `refetchInterval`, `staleTime`, etc.
+
+Example wiring:
+
+```tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { InfluencerAIProvider } from '@influencerai/sdk/react';
+
+const queryClient = new QueryClient();
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <InfluencerAIProvider baseUrl={process.env.NEXT_PUBLIC_API_BASE_URL}>
+        {children}
+      </InfluencerAIProvider>
+    </QueryClientProvider>
+  );
+}
+```
+
 ## Design system & layout (WEB-06)
 
 - `tailwind.config.ts` enables the shadcn-style preset with our `brand` palette and class-based dark mode. Global tokens live in

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,8 +2,23 @@
   "name": "@influencerai/sdk",
   "version": "0.0.0",
   "private": true,
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./react": {
+      "require": "./dist/react/index.js",
+      "default": "./dist/react/index.js"
+    }
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "react": ["dist/react/index.d.ts"]
+    }
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
@@ -16,7 +31,31 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@tanstack/react-query": "^5.51.19",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "msw": "^2.6.6",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "typescript": "^5.9.3",
     "vitest": "^2.1.9"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.0.0",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@tanstack/react-query": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
   }
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -26,6 +26,13 @@ import {
 
 type QueryValue = string | number | boolean | undefined;
 
+export interface ListJobsParams {
+  status?: string;
+  type?: string;
+  take?: number;
+  skip?: number;
+}
+
 interface RequestConfig<T> {
   path: string;
   method?: string;
@@ -110,7 +117,7 @@ export class InfluencerAIClient {
     return this.request({ path: `/jobs/${id}`, schema: JobResponseSchema });
   }
 
-  async listJobs(params: { status?: string; type?: string; take?: number; skip?: number } = {}) {
+  async listJobs(params: ListJobsParams = {}) {
     const query: Record<string, QueryValue> = {
       status: params.status,
       type: params.type,
@@ -163,3 +170,4 @@ export type {
   ContentPlanEnvelope,
 } from './types';
 export { APIError as InfluencerAIAPIError } from './fetch-utils';
+export type { ListJobsParams };

--- a/packages/sdk/src/react/hooks.ts
+++ b/packages/sdk/src/react/hooks.ts
@@ -1,0 +1,157 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationOptions,
+  type UseMutationResult,
+  type UseQueryOptions,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+
+import type {
+  CreateDatasetInput,
+  CreateDatasetResponse,
+  Dataset,
+  JobResponse,
+  QueueSummary,
+  ContentPlanEnvelope,
+} from '../types';
+import type { JobSpec, ContentPlan } from '../core-schemas';
+import type { ListJobsParams } from '../index';
+import type { APIError as InfluencerAIAPIError } from '../fetch-utils';
+import { useInfluencerAIClient } from './provider';
+import { influencerAIQueryKeys } from './query-keys';
+
+const identity = <T,>(value: T) => value;
+
+type QueryOptions<TData> = Omit<UseQueryOptions<TData, InfluencerAIAPIError>, 'queryKey' | 'queryFn'>;
+
+type MutationOptions<TData, TVariables, TContext = unknown> = Omit<
+  UseMutationOptions<TData, InfluencerAIAPIError, TVariables, TContext>,
+  'mutationFn'
+>;
+
+export type UseJobsOptions = QueryOptions<JobResponse[]>;
+export type UseJobOptions = QueryOptions<JobResponse>;
+export type UseDatasetsOptions = QueryOptions<Dataset[]>;
+export type UseQueuesSummaryOptions = QueryOptions<QueueSummary>;
+export type UseContentPlanOptions = QueryOptions<ContentPlanEnvelope>;
+export type UseCreateJobOptions<TContext = unknown> = MutationOptions<JobResponse, JobSpec, TContext>;
+export type UseCreateDatasetOptions<TContext = unknown> = MutationOptions<CreateDatasetResponse, CreateDatasetInput, TContext>;
+export type UseCreateContentPlanOptions<TContext = unknown> = MutationOptions<
+  ContentPlanEnvelope,
+  Omit<ContentPlan, 'createdAt'>,
+  TContext
+>;
+
+export function useJobs(
+  filters?: ListJobsParams,
+  options?: UseJobsOptions,
+): UseQueryResult<JobResponse[], InfluencerAIAPIError> {
+  const client = useInfluencerAIClient();
+
+  return useQuery<JobResponse[], InfluencerAIAPIError>({
+    queryKey: influencerAIQueryKeys.jobs.list(filters),
+    queryFn: () => client.listJobs(filters ?? {}),
+    ...options,
+  });
+}
+
+export function useJob(id: string, options?: UseJobOptions): UseQueryResult<JobResponse, InfluencerAIAPIError> {
+  const client = useInfluencerAIClient();
+
+  return useQuery<JobResponse, InfluencerAIAPIError>({
+    queryKey: influencerAIQueryKeys.jobs.detail(id),
+    queryFn: () => client.getJob(id),
+    enabled: options?.enabled ?? Boolean(id),
+    ...options,
+  });
+}
+
+export function useDatasets(options?: UseDatasetsOptions): UseQueryResult<Dataset[], InfluencerAIAPIError> {
+  const client = useInfluencerAIClient();
+
+  return useQuery<Dataset[], InfluencerAIAPIError>({
+    queryKey: influencerAIQueryKeys.datasets.list(),
+    queryFn: () => client.listDatasets(),
+    ...options,
+  });
+}
+
+export function useQueuesSummary(options?: UseQueuesSummaryOptions): UseQueryResult<QueueSummary, InfluencerAIAPIError> {
+  const client = useInfluencerAIClient();
+
+  return useQuery<QueueSummary, InfluencerAIAPIError>({
+    queryKey: influencerAIQueryKeys.queues.summary(),
+    queryFn: () => client.getQueuesSummary(),
+    ...options,
+  });
+}
+
+export function useContentPlan(
+  id: string,
+  options?: UseContentPlanOptions,
+): UseQueryResult<ContentPlanEnvelope, InfluencerAIAPIError> {
+  const client = useInfluencerAIClient();
+
+  return useQuery<ContentPlanEnvelope, InfluencerAIAPIError>({
+    queryKey: influencerAIQueryKeys.contentPlans.detail(id),
+    queryFn: () => client.getContentPlan(id),
+    enabled: options?.enabled ?? Boolean(id),
+    ...options,
+  });
+}
+
+export function useCreateJob<TContext = unknown>(
+  options?: UseCreateJobOptions<TContext>,
+): UseMutationResult<JobResponse, InfluencerAIAPIError, JobSpec, TContext> {
+  const client = useInfluencerAIClient();
+  const queryClient = useQueryClient();
+  const { onSuccess = identity, ...rest } = options ?? {};
+
+  return useMutation<JobResponse, InfluencerAIAPIError, JobSpec, TContext>({
+    mutationFn: (input) => client.createJob(input),
+    async onSuccess(data, variables, context) {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: influencerAIQueryKeys.jobs.root }),
+        queryClient.invalidateQueries({ queryKey: influencerAIQueryKeys.queues.root }),
+      ]);
+      await onSuccess(data, variables, context);
+    },
+    ...rest,
+  });
+}
+
+export function useCreateDataset<TContext = unknown>(
+  options?: UseCreateDatasetOptions<TContext>,
+): UseMutationResult<CreateDatasetResponse, InfluencerAIAPIError, CreateDatasetInput, TContext> {
+  const client = useInfluencerAIClient();
+  const queryClient = useQueryClient();
+  const { onSuccess = identity, ...rest } = options ?? {};
+
+  return useMutation<CreateDatasetResponse, InfluencerAIAPIError, CreateDatasetInput, TContext>({
+    mutationFn: (input) => client.createDataset(input),
+    async onSuccess(data, variables, context) {
+      await queryClient.invalidateQueries({ queryKey: influencerAIQueryKeys.datasets.root });
+      await onSuccess(data, variables, context);
+    },
+    ...rest,
+  });
+}
+
+export function useCreateContentPlan<TContext = unknown>(
+  options?: UseCreateContentPlanOptions<TContext>,
+): UseMutationResult<ContentPlanEnvelope, InfluencerAIAPIError, Omit<ContentPlan, 'createdAt'>, TContext> {
+  const client = useInfluencerAIClient();
+  const queryClient = useQueryClient();
+  const { onSuccess = identity, ...rest } = options ?? {};
+
+  return useMutation<ContentPlanEnvelope, InfluencerAIAPIError, Omit<ContentPlan, 'createdAt'>, TContext>({
+    mutationFn: (input) => client.createContentPlan(input),
+    async onSuccess(data, variables, context) {
+      await queryClient.invalidateQueries({ queryKey: influencerAIQueryKeys.contentPlans.root });
+      await onSuccess(data, variables, context);
+    },
+    ...rest,
+  });
+}

--- a/packages/sdk/src/react/index.ts
+++ b/packages/sdk/src/react/index.ts
@@ -1,0 +1,24 @@
+export { InfluencerAIProvider, useInfluencerAIClient } from './provider';
+export type { InfluencerAIProviderProps } from './provider';
+export { influencerAIQueryKeys } from './query-keys';
+export type { InfluencerAIQueryKeys } from './query-keys';
+export {
+  useJobs,
+  useJob,
+  useDatasets,
+  useQueuesSummary,
+  useContentPlan,
+  useCreateJob,
+  useCreateDataset,
+  useCreateContentPlan,
+} from './hooks';
+export type {
+  UseJobsOptions,
+  UseJobOptions,
+  UseDatasetsOptions,
+  UseQueuesSummaryOptions,
+  UseContentPlanOptions,
+  UseCreateJobOptions,
+  UseCreateDatasetOptions,
+  UseCreateContentPlanOptions,
+} from './hooks';

--- a/packages/sdk/src/react/provider.tsx
+++ b/packages/sdk/src/react/provider.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+
+import { InfluencerAIClient } from '../index';
+
+const InfluencerAIClientContext = createContext<InfluencerAIClient | null>(null);
+
+export interface InfluencerAIProviderProps {
+  children: ReactNode;
+  baseUrl?: string;
+  client?: InfluencerAIClient;
+}
+
+export function InfluencerAIProvider({ children, baseUrl, client }: InfluencerAIProviderProps) {
+  const value = useMemo(() => client ?? new InfluencerAIClient(baseUrl), [client, baseUrl]);
+
+  return <InfluencerAIClientContext.Provider value={value}>{children}</InfluencerAIClientContext.Provider>;
+}
+
+export function useInfluencerAIClient(): InfluencerAIClient {
+  const ctx = useContext(InfluencerAIClientContext);
+  if (!ctx) {
+    throw new Error('useInfluencerAIClient must be used within an InfluencerAIProvider');
+  }
+  return ctx;
+}

--- a/packages/sdk/src/react/query-keys.ts
+++ b/packages/sdk/src/react/query-keys.ts
@@ -1,0 +1,32 @@
+import type { ListJobsParams } from '../index';
+
+const JOBS_ROOT = ['influencerai', 'jobs'] as const;
+const DATASETS_ROOT = ['influencerai', 'datasets'] as const;
+const QUEUES_ROOT = ['influencerai', 'queues'] as const;
+const CONTENT_PLANS_ROOT = ['influencerai', 'content-plans'] as const;
+
+function normalizeJobsFilters(filters?: ListJobsParams) {
+  return [filters?.status ?? null, filters?.type ?? null, filters?.take ?? null, filters?.skip ?? null] as const;
+}
+
+export const influencerAIQueryKeys = {
+  jobs: {
+    root: JOBS_ROOT,
+    list: (filters?: ListJobsParams) => [...JOBS_ROOT, 'list', ...normalizeJobsFilters(filters)] as const,
+    detail: (id: string) => [...JOBS_ROOT, 'detail', id] as const,
+  },
+  datasets: {
+    root: DATASETS_ROOT,
+    list: () => [...DATASETS_ROOT, 'list'] as const,
+  },
+  queues: {
+    root: QUEUES_ROOT,
+    summary: () => [...QUEUES_ROOT, 'summary'] as const,
+  },
+  contentPlans: {
+    root: CONTENT_PLANS_ROOT,
+    detail: (id: string) => [...CONTENT_PLANS_ROOT, 'detail', id] as const,
+  },
+} as const;
+
+export type InfluencerAIQueryKeys = typeof influencerAIQueryKeys;

--- a/packages/sdk/test/react-hooks.test.tsx
+++ b/packages/sdk/test/react-hooks.test.tsx
@@ -1,0 +1,129 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { ReactNode } from 'react';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { influencerAIQueryKeys } from '../src/react/query-keys';
+import { InfluencerAIProvider } from '../src/react/provider';
+import { useCreateJob, useDatasets, useJobs, useQueuesSummary } from '../src/react/hooks';
+
+const API_BASE_URL = 'https://sdk.test';
+
+const server = setupServer(
+  http.get(`${API_BASE_URL}/jobs`, () =>
+    HttpResponse.json([
+      {
+        id: 'job-1',
+        status: 'pending',
+        type: 'content-generation',
+        payload: { foo: 'bar' },
+        createdAt: new Date().toISOString(),
+      },
+    ]),
+  ),
+  http.post(`${API_BASE_URL}/jobs`, async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json({
+      id: 'job-created',
+      status: 'pending',
+      type: 'content-generation',
+      payload: body,
+      createdAt: new Date().toISOString(),
+    });
+  }),
+  http.get(`${API_BASE_URL}/queues/summary`, () =>
+    HttpResponse.json({ active: 2, waiting: 5, failed: 1 }),
+  ),
+  http.get(`${API_BASE_URL}/datasets`, () =>
+    HttpResponse.json([
+      {
+        id: 'dataset-1',
+        kind: 'lora-training',
+        path: '/datasets/dataset-1',
+        status: 'READY',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ]),
+  ),
+);
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <InfluencerAIProvider baseUrl={API_BASE_URL}>{children}</InfluencerAIProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('React Query hooks', () => {
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  it('retrieves the jobs list', async () => {
+    const queryClient = createTestQueryClient();
+    const wrapper = createWrapper(queryClient);
+    const { result } = renderHook(() => useJobs(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.[0]?.id).toBe('job-1');
+
+    queryClient.clear();
+  });
+
+  it('invalidates jobs and queues after creating a job', async () => {
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = createWrapper(queryClient);
+
+    const mutation = renderHook(() => useCreateJob(), { wrapper });
+
+    await act(async () => {
+      await mutation.result.current.mutateAsync({
+        type: 'content-generation',
+        payload: { foo: 'bar' },
+      } as any);
+    });
+
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: influencerAIQueryKeys.jobs.root }),
+      ),
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: influencerAIQueryKeys.queues.root }),
+    );
+
+    expect(mutation.result.current.data?.id).toBe('job-created');
+
+    queryClient.clear();
+  });
+
+  it('loads datasets and queue summary data', async () => {
+    const queryClient = createTestQueryClient();
+    const wrapper = createWrapper(queryClient);
+
+    const datasets = renderHook(() => useDatasets(), { wrapper });
+    const queues = renderHook(() => useQueuesSummary(), { wrapper });
+
+    await waitFor(() => expect(datasets.result.current.isSuccess).toBe(true));
+    await waitFor(() => expect(queues.result.current.isSuccess).toBe(true));
+
+    expect(datasets.result.current.data?.[0]?.id).toBe('dataset-1');
+    expect(queues.result.current.data).toMatchObject({ active: 2, waiting: 5, failed: 1 });
+
+    queryClient.clear();
+  });
+});

--- a/packages/sdk/test/setup-tests.ts
+++ b/packages/sdk/test/setup-tests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2021",
     "lib": ["ES2021", "DOM"],
     "module": "commonjs",
+    "jsx": "react-jsx",
     "declaration": true,
     "outDir": "./dist",
     "rootDir": "./src",

--- a/packages/sdk/tsconfig.vitest.json
+++ b/packages/sdk/tsconfig.vitest.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": true,
     "rootDir": ".",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src/**/*", "test/**/*"]
 }

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -3,8 +3,9 @@ import { resolve } from 'node:path';
 
 export default defineConfig({
   test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts', 'test/**/*.test.ts'],
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts', 'test/**/*.test.{ts,tsx}'],
+    setupFiles: ['./test/setup-tests.ts'],
     typecheck: {
       tsconfig: './tsconfig.vitest.json',
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0)
+        version: 2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3))(terser@5.44.0)
       wait-on:
         specifier: ^8.0.1
         version: 8.0.5
@@ -280,7 +280,7 @@ importers:
         version: 3.4.18(tsx@4.20.6)(yaml@2.8.1)
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0)
+        version: 2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3))(terser@5.44.0)
 
   apps/worker:
     dependencies:
@@ -367,13 +367,13 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^3.0.4
-        version: 3.2.4(vitest@3.2.4(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0))
+        version: 3.2.4(vitest@3.2.4(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3))(terser@5.44.0))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^3.0.4
-        version: 3.2.4(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0)
+        version: 3.2.4(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3))(terser@5.44.0)
 
   packages/prompts:
     devDependencies:
@@ -382,7 +382,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0)
+        version: 2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3))(terser@5.44.0)
 
   packages/sdk:
     dependencies:
@@ -393,12 +393,36 @@ importers:
         specifier: ^3.24.1
         version: 3.25.76
     devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.51.19
+        version: 5.90.2(react@18.3.1)
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.2.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.26
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.7(@types/react@18.3.26)
+      msw:
+        specifier: ^2.6.6
+        version: 2.11.5(@types/node@22.18.7)(typescript@5.9.3)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0)
+        version: 2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3))(terser@5.44.0)
 
   tests/e2e:
     dependencies:
@@ -420,7 +444,7 @@ importers:
         version: 4.20.6
       vitest:
         specifier: ^2.1.4
-        version: 2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0)
+        version: 2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3))(terser@5.44.0)
       wait-on:
         specifier: ^7.2.0
         version: 7.2.0
@@ -1407,6 +1431,41 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/ansi@1.0.1':
+    resolution: {integrity: sha512-yqq0aJW/5XPhi5xOAL1xRCpe1eh8UFVgYFpFsjEqmIR8rKLyP+HINvFXwUaxYICflJrVlxnp7lLN6As735kVpw==}
+    engines: {node: '>=18'}
+
+  '@inquirer/confirm@5.1.19':
+    resolution: {integrity: sha512-wQNz9cfcxrtEnUyG5PndC8g3gZ7lGDBzmWiXZkX8ot3vfZ+/BLjR8EvyGX4YzQLeVqtAlY/YScZpW7CW8qMoDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.0':
+    resolution: {integrity: sha512-Uv2aPPPSK5jeCplQmQ9xadnFx2Zhj9b5Dj7bU6ZeCdDNNY11nhYy4btcSdtDguHqCT2h5oNeQTcUNSGGLA7NTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.14':
+    resolution: {integrity: sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/type@3.0.9':
+    resolution: {integrity: sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@ioredis/commands@1.4.0':
     resolution: {integrity: sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==}
 
@@ -1558,6 +1617,10 @@ packages:
     resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
     cpu: [x64]
     os: [win32]
+
+  '@mswjs/interceptors@0.39.8':
+    resolution: {integrity: sha512-2+BzZbjRO7Ct61k8fMNHEtoKjeWI9pIlHFTqBwZ5icHpqszIgEZbjb1MW5Z0+bITTCTl3gk4PDBxs9tA/csXvA==}
+    engines: {node: '>=18'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -1774,6 +1837,15 @@ packages:
     resolution: {integrity: sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@paralleldrive/cuid2@2.2.2':
     resolution: {integrity: sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==}
@@ -2616,16 +2688,27 @@ packages:
   '@types/node@22.18.7':
     resolution: {integrity: sha512-3E97nlWEVp2V6J7aMkR8eOnw/w0pArPwf/5/W0865f+xzBoGL/ZuHkTAKAGN7cOWNwd+sG+hZOqj+fjzeHS75g==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
   '@types/react-dom@19.1.9':
     resolution: {integrity: sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==}
     peerDependencies:
       '@types/react': ^19.0.0
+
+  '@types/react@18.3.26':
+    resolution: {integrity: sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==}
 
   '@types/react@19.1.15':
     resolution: {integrity: sha512-+kLxJpaJzXybyDyFXYADyP1cznTO8HSuBpenGlnKOAkH4hyNINiywvXS/tGJhsrGGP/gM185RA3xpjY0Yg4erA==}
@@ -2641,6 +2724,9 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
   '@types/superagent@8.1.9':
     resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
@@ -4385,6 +4471,10 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  graphql@16.11.0:
+    resolution: {integrity: sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
@@ -4420,6 +4510,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
@@ -4599,6 +4692,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -5260,12 +5356,26 @@ packages:
   msgpackr@1.11.5:
     resolution: {integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==}
 
+  msw@2.11.5:
+    resolution: {integrity: sha512-atFI4GjKSJComxcigz273honh8h4j5zzpk5kwG4tGm0TPcYne6bqmVrufeRll6auBeouIkXqZYXxVbWSWxM3RA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
   mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -5467,6 +5577,9 @@ packages:
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
+
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -5832,6 +5945,11 @@ packages:
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
   react-dom@19.2.0:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
     peerDependencies:
@@ -5879,6 +5997,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
 
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
@@ -5985,6 +6107,9 @@ packages:
     resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
     engines: {node: '>=10'}
 
+  rettime@0.7.0:
+    resolution: {integrity: sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw==}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -6051,6 +6176,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -6224,6 +6352,10 @@ packages:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
@@ -6233,6 +6365,9 @@ packages:
 
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
@@ -6481,6 +6616,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.17:
+    resolution: {integrity: sha512-DieYoGrP78PWKsrXr8MZwtQ7GLCUeLxihtjC1jZsW1DnvSMdKPitJSe8OSYDM2u5H6g3kWJZpePqkp43TfLh0g==}
+
+  tldts@7.0.17:
+    resolution: {integrity: sha512-Y1KQBgDd/NUc+LfOtKS6mNsC9CCaH+m2P1RoIZy7RAPo3C3/t8X45+zgut31cRZtZ3xKPjfn3TkGTrctC2TQIQ==}
+    hasBin: true
+
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
@@ -6507,6 +6649,10 @@ packages:
   tough-cookie@4.1.4:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
+
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -6723,6 +6869,9 @@ packages:
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
@@ -7084,6 +7233,10 @@ packages:
   yocto-queue@1.2.1:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
 
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
@@ -8279,6 +8432,34 @@ snapshots:
   '@img/sharp-win32-x64@0.34.4':
     optional: true
 
+  '@inquirer/ansi@1.0.1': {}
+
+  '@inquirer/confirm@5.1.19(@types/node@22.18.7)':
+    dependencies:
+      '@inquirer/core': 10.3.0(@types/node@22.18.7)
+      '@inquirer/type': 3.0.9(@types/node@22.18.7)
+    optionalDependencies:
+      '@types/node': 22.18.7
+
+  '@inquirer/core@10.3.0(@types/node@22.18.7)':
+    dependencies:
+      '@inquirer/ansi': 1.0.1
+      '@inquirer/figures': 1.0.14
+      '@inquirer/type': 3.0.9(@types/node@22.18.7)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.18.7
+
+  '@inquirer/figures@1.0.14': {}
+
+  '@inquirer/type@3.0.9(@types/node@22.18.7)':
+    optionalDependencies:
+      '@types/node': 22.18.7
+
   '@ioredis/commands@1.4.0': {}
 
   '@isaacs/cliui@8.0.2':
@@ -8523,6 +8704,15 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
+  '@mswjs/interceptors@0.39.8':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.5.0
@@ -8728,6 +8918,15 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@paralleldrive/cuid2@2.2.2':
     dependencies:
@@ -9468,6 +9667,11 @@ snapshots:
 
   '@tanstack/query-core@5.90.2': {}
 
+  '@tanstack/react-query@5.90.2(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.90.2
+      react: 18.3.1
+
   '@tanstack/react-query@5.90.2(react@19.2.0)':
     dependencies:
       '@tanstack/query-core': 5.90.2
@@ -9492,6 +9696,16 @@ snapshots:
       dom-accessibility-api: 0.6.3
       picocolors: 1.1.1
       redent: 3.0.0
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+      '@types/react-dom': 18.3.7(@types/react@18.3.26)
 
   '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -9635,13 +9849,24 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/prop-types@15.7.15': {}
+
   '@types/qs@6.14.0': {}
 
   '@types/range-parser@1.2.7': {}
 
+  '@types/react-dom@18.3.7(@types/react@18.3.26)':
+    dependencies:
+      '@types/react': 18.3.26
+
   '@types/react-dom@19.1.9(@types/react@19.1.15)':
     dependencies:
       '@types/react': 19.1.15
+
+  '@types/react@18.3.26':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.1.3
 
   '@types/react@19.1.15':
     dependencies:
@@ -9663,6 +9888,8 @@ snapshots:
       '@types/send': 0.17.5
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/statuses@2.0.6': {}
 
   '@types/superagent@8.1.9':
     dependencies:
@@ -9902,7 +10129,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3))(terser@5.44.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -9917,7 +10144,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0)
+      vitest: 3.2.4(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3))(terser@5.44.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9942,20 +10169,22 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.20(@types/node@22.18.7)(lightningcss@1.30.1)(terser@5.44.0))':
+  '@vitest/mocker@2.1.9(msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3))(vite@5.4.20(@types/node@22.18.7)(lightningcss@1.30.1)(terser@5.44.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
+      msw: 2.11.5(@types/node@22.18.7)(typescript@5.9.3)
       vite: 5.4.20(@types/node@22.18.7)(lightningcss@1.30.1)(terser@5.44.0)
 
-  '@vitest/mocker@3.2.4(vite@5.4.20(@types/node@22.18.7)(lightningcss@1.30.1)(terser@5.44.0))':
+  '@vitest/mocker@3.2.4(msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3))(vite@5.4.20(@types/node@22.18.7)(lightningcss@1.30.1)(terser@5.44.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
+      msw: 2.11.5(@types/node@22.18.7)(typescript@5.9.3)
       vite: 5.4.20(@types/node@22.18.7)(lightningcss@1.30.1)(terser@5.44.0)
 
   '@vitest/pretty-format@2.1.9':
@@ -11899,6 +12128,8 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphql@16.11.0: {}
+
   handlebars@4.7.8:
     dependencies:
       minimist: 1.2.8
@@ -11931,6 +12162,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  headers-polyfill@4.0.3: {}
 
   help-me@5.0.0: {}
 
@@ -12142,6 +12375,8 @@ snapshots:
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -12988,9 +13223,36 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
+  msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.19(@types/node@22.18.7)
+      '@mswjs/interceptors': 0.39.8
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.0.2
+      graphql: 16.11.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.7.0
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 4.41.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
   mute-stream@0.0.8: {}
 
   mute-stream@1.0.0: {}
+
+  mute-stream@2.0.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -13193,6 +13455,8 @@ snapshots:
       wcwidth: 1.0.1
 
   os-tmpdir@1.0.2: {}
+
+  outvariant@1.4.3: {}
 
   own-keys@1.0.1:
     dependencies:
@@ -13600,6 +13864,12 @@ snapshots:
       defu: 6.1.4
       destr: 2.0.5
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
   react-dom@19.2.0(react@19.2.0):
     dependencies:
       react: 19.2.0
@@ -13639,6 +13909,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.15
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   react@19.2.0: {}
 
@@ -13743,6 +14017,8 @@ snapshots:
 
   ret@0.5.0: {}
 
+  rettime@0.7.0: {}
+
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
@@ -13834,6 +14110,10 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
     optional: true
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   scheduler@0.27.0: {}
 
@@ -14050,6 +14330,8 @@ snapshots:
 
   statuses@2.0.1: {}
 
+  statuses@2.0.2: {}
+
   std-env@3.9.0: {}
 
   stop-iteration-iterator@1.1.0:
@@ -14065,6 +14347,8 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  strict-event-emitter@0.5.1: {}
 
   string-length@4.0.2:
     dependencies:
@@ -14370,6 +14654,12 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.0.17: {}
+
+  tldts@7.0.17:
+    dependencies:
+      tldts-core: 7.0.17
+
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
@@ -14397,6 +14687,10 @@ snapshots:
       universalify: 0.2.0
       url-parse: 1.5.10
     optional: true
+
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.17
 
   tr46@0.0.3: {}
 
@@ -14623,6 +14917,8 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
+  until-async@3.0.2: {}
+
   update-browserslist-db@1.1.3(browserslist@4.26.2):
     dependencies:
       browserslist: 4.26.2
@@ -14774,10 +15070,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0):
+  vitest@2.1.9(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3))(terser@5.44.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.20(@types/node@22.18.7)(lightningcss@1.30.1)(terser@5.44.0))
+      '@vitest/mocker': 2.1.9(msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3))(vite@5.4.20(@types/node@22.18.7)(lightningcss@1.30.1)(terser@5.44.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -14810,11 +15106,11 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.2.4(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(terser@5.44.0):
+  vitest@3.2.4(@types/node@22.18.7)(jsdom@24.1.3)(lightningcss@1.30.1)(msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3))(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.20(@types/node@22.18.7)(lightningcss@1.30.1)(terser@5.44.0))
+      '@vitest/mocker': 3.2.4(msw@2.11.5(@types/node@22.18.7)(typescript@5.9.3))(vite@5.4.20(@types/node@22.18.7)(lightningcss@1.30.1)(terser@5.44.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -15064,6 +15360,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.1: {}
+
+  yoctocolors-cjs@2.1.3: {}
 
   zod@3.23.8: {}
 


### PR DESCRIPTION
## Summary
- add a React provider, query keys, and TanStack Query hooks that wrap the InfluencerAI SDK
- expose the hooks through a dedicated subpath export and configure the package for JSX/msw-based testing
- document hook adoption in the web dashboard guide for future integration

## Testing
- pnpm --filter @influencerai/sdk test -- --all

------
https://chatgpt.com/codex/tasks/task_e_68f01c1603888320bb5ce9171df34519