### PR TITLE
fix: enforce strict boolean env parsing

### DIFF
--- a/apps/api/src/config/__tests__/env.validation.spec.ts
+++ b/apps/api/src/config/__tests__/env.validation.spec.ts
@@ -36,6 +36,17 @@ describe('validateEnv', () => {
     expect(env.LOG_LEVEL).toBe('info');
   });
 
+  it('rejects invalid boolean-like inputs', () => {
+    expect(() =>
+      validateEnv({
+        DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
+        NODE_ENV: 'production',
+        SKIP_S3_INIT: 'treu',
+        OPENROUTER_API_KEY: 'sk-test',
+      }),
+    ).toThrow(/boolean/i);
+  });
+
   it('throws when OPENROUTER_API_KEY is missing outside test environments', () => {
     expect(() =>
       validateEnv({
@@ -96,6 +107,15 @@ describe('validateEnv', () => {
           DISABLE_BULL: 'Yes',
         }),
       ).toBe(false);
+    });
+
+    it('throws when DISABLE_BULL is an invalid boolean-like value', () => {
+      expect(() =>
+        computeBullEnabled({
+          NODE_ENV: 'development',
+          DISABLE_BULL: 'nah',
+        }),
+      ).toThrow(/boolean/i);
     });
   });
 });

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -9,12 +9,21 @@ const coerceOptionalBoolean = (value: BooleanLike): boolean | undefined => {
   if (value === undefined || value === null) {
     return undefined;
   }
+
   if (typeof value === 'boolean') {
     return value;
   }
+
   if (typeof value === 'number') {
-    return value !== 0;
+    if (value === 1) {
+      return true;
+    }
+    if (value === 0) {
+      return false;
+    }
+    throw new Error('Invalid boolean value');
   }
+
   if (typeof value === 'string') {
     const normalized = value.trim().toLowerCase();
     if (truthyStrings.has(normalized)) {
@@ -23,9 +32,10 @@ const coerceOptionalBoolean = (value: BooleanLike): boolean | undefined => {
     if (falsyStrings.has(normalized)) {
       return false;
     }
-    return false;
+    throw new Error('Invalid boolean value');
   }
-  return false;
+
+  throw new Error('Invalid boolean value');
 };
 
 const normalizeNodeEnv = (value: unknown): 'development' | 'production' | 'test' => {


### PR DESCRIPTION
## Summary
- raise validation errors for unrecognized boolean-like environment values
- keep computeBullEnabled consistent with stricter parsing and add regression coverage

## Testing
- pnpm --filter @influencerai/api test -- env.validation

------
https://chatgpt.com/codex/tasks/task_e_68f0bad111108320a2ca2c945f7e55cd