### PR TITLE
WEB-06: Align breadcrumb labels with navigation config

### DIFF
--- a/apps/web/README.dashboard.md
+++ b/apps/web/README.dashboard.md
@@ -74,4 +74,6 @@ export function Providers({ children }: { children: React.ReactNode }) {
     actions, breadcrumb trail, and responsive mobile navigation.
   - To onboard a new view, place the page under `src/app/(dashboard)/` and render its content directly—the shell handles padding,
     chrome, and breadcrumbs.
-  - Navigation items live in `src/components/layout/nav-config.ts`; update this file to surface new primary or support links.
+- Navigation items live in `src/components/layout/nav-config.ts`; update this file to surface new primary or support links.
+- Breadcrumb labels reuse the titles declared in `nav-config.ts`, keeping sidebar and breadcrumb terminology in sync. Use the
+  overrides map in `app-breadcrumbs.tsx` for single-route tweaks (e.g. `/login`).

--- a/apps/web/src/components/layout/__tests__/app-breadcrumbs.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/app-breadcrumbs.spec.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AppBreadcrumbs } from "@/components/layout/app-breadcrumbs";
+
+const mockUsePathname = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: { children: ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("AppBreadcrumbs", () => {
+  it("formats breadcrumb labels using nav titles and title casing", () => {
+    mockUsePathname.mockReturnValue("/dashboard/content-plans/new-campaign");
+
+    render(<AppBreadcrumbs />);
+
+    expect(screen.getByRole("link", { name: "Dashboard" })).toHaveAttribute("href", "/dashboard");
+    expect(screen.getByRole("link", { name: "Content Plans" })).toHaveAttribute(
+      "href",
+      "/dashboard/content-plans",
+    );
+    expect(screen.getByText("New Campaign")).toBeInTheDocument();
+  });
+});
+

--- a/apps/web/src/components/layout/__tests__/app-shell.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/app-shell.spec.tsx
@@ -57,7 +57,7 @@ describe("AppShell", () => {
 
     expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute("href", "/");
     expect(screen.getByRole("link", { name: "Dashboard" })).toHaveAttribute("href", "/dashboard");
-    expect(screen.getByRole("link", { name: "Content plans" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "Content Plans" })).toHaveAttribute(
       "href",
       "/dashboard/content-plans",
     );

--- a/apps/web/src/components/layout/app-breadcrumbs.tsx
+++ b/apps/web/src/components/layout/app-breadcrumbs.tsx
@@ -11,15 +11,28 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 
-const labelMap: Record<string, string> = {
-  dashboard: "Dashboard",
-  jobs: "Jobs",
-  library: "Library",
-  login: "Login",
-};
+import { mainNav } from "./nav-config";
 
-function titleCase(segment: string) {
-  return segment.charAt(0).toUpperCase() + segment.slice(1);
+const LABEL_OVERRIDES = new Map<string, string>([["/login", "Login"]]);
+
+const NAV_LABELS = mainNav.reduce((registry, item) => {
+  if (!item.href.startsWith("http")) {
+    registry.set(item.href, item.title);
+  }
+  return registry;
+}, new Map<string, string>());
+
+function toTitleCase(segment: string) {
+  const decoded = decodeURIComponent(segment);
+  return decoded
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function resolveLabel(href: string, segment: string) {
+  return NAV_LABELS.get(href) ?? LABEL_OVERRIDES.get(href) ?? toTitleCase(segment);
 }
 
 export function AppBreadcrumbs() {
@@ -28,7 +41,7 @@ export function AppBreadcrumbs() {
 
   const crumbs = segments.map((segment, index) => {
     const href = `/${segments.slice(0, index + 1).join("/")}`;
-    const label = labelMap[segment] ?? titleCase(segment.replace(/-/g, " "));
+    const label = resolveLabel(href, segment);
     const isLast = index === segments.length - 1;
     return {
       href,


### PR DESCRIPTION
## Summary
- reuse the sidebar navigation config to resolve breadcrumb labels and ensure consistent title casing
- cover the breadcrumb formatter with unit tests and document the nav-driven behaviour in the dashboard readme

## Testing
- pnpm --filter @influencerai/web test:unit -- --force-all

------
https://chatgpt.com/codex/tasks/task_e_68f0f696454083209dbd5b371370284e